### PR TITLE
Define PIDDIR to "/run/"

### DIFF
--- a/src/pathnames.h
+++ b/src/pathnames.h
@@ -37,7 +37,7 @@
 			 * (Don't ask why the default is "/etc/".)
 			 */
 #ifdef _PATH_VARRUN
-# define PIDDIR	_PATH_VARRUN
+# define PIDDIR	"/run/"
 #else
 # define PIDDIR SYSCONFDIR "/"
 #endif


### PR DESCRIPTION
Define PIDDIR to "/run/" instead of the (outdated) definition
coming from glibc "paths.h".

This change originally comes from cronie-piddir.patch added to
openSUSE by Cristian Rodríguez (crrodriguez@opensuse.org).