### PR TITLE
Avoid creating pid files when crond doesn't fork

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -315,6 +315,8 @@ void acquire_daemonlock(int closeflag) {
 		return;
 	}
 
+	if(NoFork == 1) return; //move along, nothing to do here...
+
 	if (fd == -1) {
 		pidfile = _PATH_CRON_PID;
 		/* Initial mode is 0600 to prevent flock() race/DoS. */


### PR DESCRIPTION
When the cron daemon does not fork, as it is the case when using
systemd, pid files are useless. Avoid creating them in the first
place.

This change originally comes from cronie-nofork-nopid.patch
added to openSUSE by Cristian Rodríguez (crrodriguez@opensuse.org).