### PR TITLE
Add Arch Linux to list of distributions @ readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ Cronie is packaged by these distributions:
 - Gentoo [http://packages.gentoo.org/package/sys-process/cronie]
 - Source Mage [http://dbg.download.sourcemage.org/grimoire/codex/stable/utils/cronie/]
 - OpenSUSE replacement of default with cronie [http://lists.suse.com/opensuse-features/2010-09/msg00217.html]
+- Arch Linux [https://www.archlinux.org/packages/core/x86_64/cronie/]
 
 # Contact
 


### PR DESCRIPTION
Arch Linux has been shipping cronie as a default since forever