### PR TITLE
Fix SELinux denial when running under Docker

### DIFF
--- a/src/security.c
+++ b/src/security.c
@@ -101,7 +101,11 @@ static int cron_get_job_range(user * u, security_context_t * ucontextp,
 
 void cron_restore_default_security_context(void) {
 #ifdef WITH_SELINUX
-	setexeccon(NULL);
+	if (is_selinux_enabled() <= 0)
+		return;
+	if (setexeccon(NULL) < 0)
+		log_it("CRON", getpid(), "ERROR",
+			"failed to restore SELinux context", 0);
 #endif
 }
 


### PR DESCRIPTION
When crond is running insider a Docker container hosted on
on a system with SELinux enabled (such as Fedora 26), the
following denial occurs each time crond executes a job:

2017-07-14T13:42:01.931319+00:00 f26docker auth.notice audit: AVC avc:  denied  { setexec } for  pid=16248 comm="crond" scontext=system_u:system_r:container_t:s0:c525,c757 tcontext=system_u:system_r:container_t:s0:c525,c757 tclass=process permissive=0

The denials get flagged as a problem by system management tools.

This patch fixes the problem by ensuring that SELinux is
enabled before trying to restore the default security context.

Software versions:
- cronie-1.5.1-5.fc26.x86_64
- selinux-policy-targeted-3.13.1-259.fc26.noarch
- docker-1.13.1-19.git27e468e.fc26.x86_64
- kernel-4.11.9-300.fc26.x86_64

See also
https://bugzilla.redhat.com/show_bug.cgi?id=1435516