### PR TITLE
2017wk29 warning fixes and build-sys update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 Makefile.in
 Makefile
 anacron/anacron
-anacron/anacron-paths.h
+anacron-paths.h
 anacron/Makefile
 anacron/Makefile.in
 aclocal.m4
@@ -26,8 +26,9 @@ tags
 src/crond
 src/crontab
 src/cronnext
-src/cron-paths.h
+cron-paths.h
 *~
 *.tar.*
 *.orig
 *.patch
+.dirstamp

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,16 @@
-SUBDIRS = src man anacron
+AM_CFLAGS = -I$(top_srcdir)
+
+BUILT_SOURCES =
+CLEANFILES =
+EXTRA_DIST =
+bin_PROGRAMS =
+common_nodist =
+sbin_PROGRAMS =
 
 dist_noinst_HEADERS = \
 	cronie_common.h
 
-EXTRA_DIST = \
+EXTRA_DIST += \
 	cronie.init \
 	crond.sysconfig \
 	contrib/anacrontab \
@@ -19,3 +26,7 @@ dist_pam_DATA = pam/crond
 else
 EXTRA_DIST += pam/crond
 endif
+
+include anacron/Makemodule.am
+include man/Makemodule.am
+include src/Makemodule.am

--- a/anacron/Makemodule.am
+++ b/anacron/Makemodule.am
@@ -1,23 +1,28 @@
 # Makefile.am - two binaries crond and crontab
 if ANACRON
-sbin_PROGRAMS = anacron
-endif
+sbin_PROGRAMS += anacron/anacron
+anacron_anacron_SOURCES = \
+	anacron-paths.h \
+	anacron/global.h \
+	anacron/gregor.c \
+	anacron/gregor.h \
+	anacron/lock.c \
+	anacron/log.c \
+	anacron/main.c \
+	anacron/matchrx.c \
+	anacron/matchrx.h \
+	anacron/readtab.c \
+	anacron/runjob.c
+common_nodist += anacron-paths.h
+nodist_anacron_anacron_SOURCES = $(common_nodist)
+BUILT_SOURCES += $(common_nodist)
 
-anacron_SOURCES = \
-  gregor.c lock.c log.c main.c matchrx.c readtab.c runjob.c \
-  $(common_src)
-common_src = global.h gregor.h matchrx.h
-common_nodist = anacron-paths.h
-nodist_anacron_SOURCES = $(common_nodist)
-BUILT_SOURCES = $(common_nodist)
-
-AM_CFLAGS = -I$(top_srcdir)
-
-LDADD = $(LIBSELINUX) $(LIBPAM) $(LIBAUDIT)
+anacron_anacron_LDADD = $(LIBSELINUX) $(LIBPAM) $(LIBAUDIT)
 
 # This header contains all the paths.
 # If they are configurable, they are declared in configure script.
 # Depends on this Makefile, because it uses make variables.
+CLEANFILES += anacron-paths.h
 anacron-paths.h: Makefile
 	@echo 'creating $@'
 	@sed >$@ 's/ *\\$$//' <<\END #\
@@ -29,3 +34,4 @@ anacron-paths.h: Makefile
 	#define ANACRONTAB "$(ANACRONTAB)" \
 	#endif /* _ANACRON_PATHS_H_ */ \
 	END
+endif

--- a/anacron/log.c
+++ b/anacron/log.c
@@ -79,7 +79,7 @@ make_msg(const char *fmt, va_list args)
     /* There's some confusion in the documentation about what vsnprintf
      * returns when the buffer overflows.  Hmmm... */
     len = vsnprintf(msg, sizeof(msg), fmt, args);
-    if (len >= sizeof(msg) - 1)
+    if (0 <= len && (size_t) len >= sizeof(msg) - 1)
 	strcpy(msg + sizeof(msg) - sizeof(truncated), truncated);
 }
 

--- a/anacron/runjob.c
+++ b/anacron/runjob.c
@@ -53,7 +53,7 @@ temp_file(job_rec *jr)
 	dir = P_tmpdir;
 
     len = snprintf(template, sizeof(template), "%s/$anacronXXXXXX", dir);
-    if (len >= sizeof(template))
+    if (0 <= len && (size_t) len >= sizeof(template))
 	die_e("TMPDIR too long");
 
     fdout = mkstemp(template);

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_INIT([cronie],[1.5.1],[mmaslano@redhat.com,tmraz@fedoraproject.org])
 AC_CONFIG_HEADER([config.h])
 AC_PREREQ(2.60)
 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])],
 			    [AC_SUBST([AM_DEFAULT_VERBOSITY], [1])])
@@ -260,6 +260,6 @@ if test "$enable_anacron" != no; then
 	ANACRON_CONF_VAR([ANACRONTAB],[The anacron table for regular jobs.],[${sysconfdir}/anacrontab])
 fi
 
-AC_CONFIG_FILES([Makefile src/Makefile man/Makefile anacron/Makefile])
+AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -253,7 +253,7 @@ CRONIE_CONF_VAR([SYSCRONTAB], [the current working directory of the running daem
 CRONIE_CONF_VAR([SYS_CROND_DIR], [the current working directory of the running daemon], [${sysconfdir}/cron.d])
 CRONIE_CONF_VAR([SPOOL_DIR], [the directory where all the user cron tabs reside], [${localstatedir}/spool/cron])
 
-AC_ARG_ENABLE([anacron], [AS_HELP_STRING([--enable-anacron], [Build also anacron.])])
+AC_ARG_ENABLE([anacron], [AS_HELP_STRING([--disable-anacron], [Do not build anacron.])], [], [enable_anacron=yes])
 AM_CONDITIONAL([ANACRON], [test "$enable_anacron" = yes])
 if test "$enable_anacron" != no; then
 	ANACRON_CONF_VAR([ANACRON_SPOOL_DIR],[The path for anacron locks.],[${localstatedir}/spool/anacron])

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,6 +1,0 @@
-dist_man_MANS = crontab.1 crontab.5 cron.8 crond.8 
-EXTRA_DIST = anacrontab.5 anacron.8
-
-if ANACRON
-dist_man_MANS += $(EXTRA_DIST)
-endif

--- a/man/Makemodule.am
+++ b/man/Makemodule.am
@@ -1,0 +1,15 @@
+dist_man_MANS = \
+	man/cron.8 \
+	man/crond.8 \
+	man/crontab.1 \
+	man/crontab.5
+
+anacron_man = \
+	man/anacrontab.5 \
+	man/anacron.8
+
+EXTRA_DIST += $(anacron_man)
+
+if ANACRON
+dist_man_MANS += $(anacron_man)
+endif

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -1,27 +1,55 @@
 # Makefile.am - two binaries crond and crontab
 
-sbin_PROGRAMS = crond
-bin_PROGRAMS = crontab cronnext
+sbin_PROGRAMS += \
+	src/crond
 
-crond_SOURCES = \
-	cron.c database.c user.c job.c do_command.c popen.c security.c \
+bin_PROGRAMS += \
+	src/cronnext \
+	src/crontab
+
+src_crond_SOURCES = \
+	src/cron.c \
+	src/database.c \
+	src/do_command.c \
+	src/job.c \
+	src/popen.c \
+	src/security.c \
+	src/user.c \
 	$(common_src)
-crontab_SOURCES = crontab.c security.c $(common_src)
-cronnext_SOURCES = \
-	cronnext.c database.c user.c job.c \
+
+src_crontab_SOURCES = \
+	src/crontab.c \
+	src/security.c \
 	$(common_src)
-common_src = entry.c env.c misc.c pw_dup.c \
-	externs.h funcs.h globals.h macros.h pathnames.h structs.h \
-	bitstring.h
-common_nodist = cron-paths.h
-nodist_crond_SOURCES = $(common_nodist)
-nodist_crontab_SOURCES = $(common_nodist)
-nodist_cronnext_SOURCES = $(common_nodist)
-BUILT_SOURCES = $(common_nodist)
 
-AM_CFLAGS = -I$(top_srcdir)
+src_cronnext_SOURCES = \
+	src/cronnext.c \
+	src/database.c \
+	src/job.c \
+	src/user.c \
+	$(common_src)
 
-LDADD = $(LIBSELINUX) $(LIBPAM) $(LIBAUDIT)
+common_src = \
+	src/bitstring.h \
+	src/entry.c \
+	src/env.c \
+	src/externs.h \
+	src/funcs.h \
+	src/globals.h \
+	src/macros.h \
+	src/misc.c \
+	src/pathnames.h \
+	src/pw_dup.c \
+	src/structs.h
+
+common_nodist += cron-paths.h
+nodist_src_crond_SOURCES = $(common_nodist)
+nodist_src_crontab_SOURCES = $(common_nodist)
+nodist_src_cronnext_SOURCES = $(common_nodist)
+BUILT_SOURCES += $(common_nodist)
+
+src_crond_LDADD = $(LIBSELINUX) $(LIBPAM) $(LIBAUDIT)
+src_crontab_LDADD = $(LIBSELINUX) $(LIBPAM) $(LIBAUDIT)
 
 ## if DEBUG
 ## noinst_PROGRAMS = debug
@@ -31,7 +59,7 @@ LDADD = $(LIBSELINUX) $(LIBPAM) $(LIBAUDIT)
 # If they are configurable, they are declared in configure script.
 # Depends on this Makefile, because it uses make variables.
 # CCD 2010/09/10 added CRON_HOSTNAME for clustered-cron.
-CLEANFILES = cron-paths.h
+CLEANFILES += cron-paths.h
 cron-paths.h: Makefile
 	@echo 'creating $@'
 	@sed >$@ 's/ *\\$$//' <<\END #\

--- a/src/cron.c
+++ b/src/cron.c
@@ -68,8 +68,9 @@ find_jobs(int, cron_db *, int, int, long),
 set_time(int),
 cron_sleep(int, cron_db *),
 sigchld_handler(int),
-sighup_handler(int),
-sigchld_reaper(void), sigintterm_handler(int), parse_args(int c, char *v[]);
+sighup_handler(int ATTRIBUTE_UNUSED),
+sigchld_reaper(void),
+sigintterm_handler(int ATTRIBUTE_UNUSED), parse_args(int c, char *v[]);
 
 static volatile sig_atomic_t got_sighup, got_sigchld, got_sigintterm;
 static int timeRunning, virtualTime, clockTime;
@@ -650,15 +651,15 @@ static void cron_sleep(int target, cron_db * db) {
 	}
 }
 
-static void sighup_handler(int x) {
+static void sighup_handler(int x ATTRIBUTE_UNUSED) {
 	got_sighup = 1;
 }
 
-static void sigchld_handler(int x) {
+static void sigchld_handler(int x ATTRIBUTE_UNUSED) {
 	got_sigchld = 1;
 }
 
-static void sigintterm_handler(int x) {
+static void sigintterm_handler(int x ATTRIBUTE_UNUSED) {
 	got_sigintterm = 1;
 }
 

--- a/src/cronnext.c
+++ b/src/cronnext.c
@@ -190,11 +190,11 @@ time_t nextmatch(entry *e, time_t start) {
 /*
  * match a user against a list
  */
-int matchuser(char *user, char *list) {
+int matchuser(char *name, char *list) {
 	char *pos;
-	int l = strlen(user);
+	int l = strlen(name);
 
-	for (pos = list; (pos = strstr(pos, user)) != NULL; pos += l) {
+	for (pos = list; (pos = strstr(pos, name)) != NULL; pos += l) {
 		if ((pos != list) && (*(pos - 1) != ','))
 			continue;
 		if ((pos[l] != '\0') && (pos[l] != ','))

--- a/src/cronnext.c
+++ b/src/cronnext.c
@@ -75,7 +75,7 @@ char *flagname[]= {
 };
 
 void printflags(int flags) {
-	int f;
+	size_t f;
 	printf("flags: 0x%d = ", flags);
 	for (f = 1; f < sizeof(flagname);  f = f << 1)
 		if (flags & f)

--- a/src/crontab.c
+++ b/src/crontab.c
@@ -413,7 +413,7 @@ static void delete_cmd(void) {
 	if (PromptOnDelete == 1) {
 		printf("crontab: really delete %s's crontab? ", User);
 		fflush(stdout);
-		if ((fgets(n, MAX_FNAME - 1, stdin) == 0L)
+		if ((fgets(n, MAX_FNAME - 1, stdin) == NULL)
 			|| ((n[0] != 'Y') && (n[0] != 'y'))
 			)
 			exit(0);
@@ -694,7 +694,7 @@ static void edit_cmd(void) {
 		perror("swapping uids back");
 		exit(ERROR_EXIT);
 	}
-	if (NewCrontab == 0L) {
+	if (NewCrontab == NULL) {
 		perror("fopen");
 		goto fatal;
 	}
@@ -706,7 +706,7 @@ static void edit_cmd(void) {
 			printf("Do you want to retry the same edit? ");
 			fflush(stdout);
 			q[0] = '\0';
-			if (fgets(q, sizeof q, stdin) == 0L)
+			if (fgets(q, sizeof q, stdin) == NULL)
 				continue;
 			switch (q[0]) {
 			case 'y':

--- a/src/crontab.c
+++ b/src/crontab.c
@@ -1014,7 +1014,7 @@ static void poke_daemon(void) {
 	}
 }
 
-static void die(int x) {
+static void die(int x ATTRIBUTE_UNUSED) {
 	if (TempFilename[0])
 		(void) unlink(TempFilename);
 	_exit(ERROR_EXIT);

--- a/src/do_command.c
+++ b/src/do_command.c
@@ -46,7 +46,7 @@ static int safe_p(const char *, const char *);
 void do_command(entry * e, user * u) {
 	pid_t pid = getpid();
 	int ev;
-	char **jobenv = 0L;
+	char **jobenv = NULL;
 
 	Debug(DPROC, ("[%ld] do_command(%s, (%s,%ld,%ld))\n",
 			(long) pid, e->cmd, u->name,
@@ -450,7 +450,7 @@ static int child_process(entry * e, char **jobenv) {
 				fprintf(mail, "Date: %s\n", arpadate(&StartTime));
 #endif /*MAIL_DATE */
 				fprintf(mail, "MIME-Version: 1.0\n");
-				if (content_type == 0L) {
+				if (content_type == NULL) {
 					fprintf(mail, "Content-Type: text/plain; charset=%s\n",
 						cron_default_mail_charset);
 				}
@@ -461,17 +461,17 @@ static int child_process(entry * e, char **jobenv) {
 					char *nl = content_type;
 					size_t ctlen = strlen(content_type);
 					while ((*nl != '\0')
-						&& ((nl = strchr(nl, '\n')) != 0L)
+						&& ((nl = strchr(nl, '\n')) != NULL)
 						&& (nl < (content_type + ctlen))
 						)
 						*nl = ' ';
 					fprintf(mail, "Content-Type: %s\n", content_type);
 				}
-				if (content_transfer_encoding != 0L) {
+				if (content_transfer_encoding != NULL) {
 					char *nl = content_transfer_encoding;
 					size_t ctlen = strlen(content_transfer_encoding);
 					while ((*nl != '\0')
-						&& ((nl = strchr(nl, '\n')) != 0L)
+						&& ((nl = strchr(nl, '\n')) != NULL)
 						&& (nl < (content_transfer_encoding + ctlen))
 						)
 						*nl = ' ';

--- a/src/popen.c
+++ b/src/popen.c
@@ -168,7 +168,7 @@ int cron_pclose(FILE * iop) {
 	 * pclose returns -1 if stream is not associated with a
 	 * `popened' command, or, if already `pclosed'.
 	 */
-	if (pids == 0 || pids[fdes = fileno(iop)] == 0)
+	if (pids == NULL || pids[fdes = fileno(iop)] == 0L)
 		return (-1);
 	(void) fclose(iop);
 

--- a/src/security.c
+++ b/src/security.c
@@ -120,7 +120,7 @@ int cron_set_job_security_context(entry *e, user *u ATTRIBUTE_UNUSED,
 		/* "minute-ly" job: Every minute for given hour/dow/month/dom. 
 		 * Ensure that these jobs never run in the same minute:
 		 */
-		minutely_time = time(0);
+		minutely_time = time(NULL);
 		Debug(DSCH, ("Minute-ly job. Recording time %lu\n", minutely_time));
 	}
 
@@ -169,7 +169,7 @@ int cron_set_job_security_context(entry *e, user *u ATTRIBUTE_UNUSED,
 
 	*jobenv = build_env(e->envp);
 
-	time_t job_run_time = time(0L);
+	time_t job_run_time = time(NULL);
 
 	if ((minutely_time > 0) && ((job_run_time / 60) != (minutely_time / 60))) {
 		/* if a per-minute job is delayed into the next minute 


### PR DESCRIPTION
First few updates are about compiler warning fixes. Two last changes are improvements to build-sys, making autotools to use none-recursive Makefile. Benefits of that approach are explained in commit reference link. The last commit changes anacron to be built by default, that is probably what most of the people want.