### PR TITLE
make cronnext able to read additional crontabs from file

### DIFF
--- a/man/cronnext.1
+++ b/man/cronnext.1
@@ -6,9 +6,9 @@ cronnext \- time of next job cron will execute
 .B cronnext
 [\fB-i \fIusers\fR] [\fB-e \fIusers\fR] [\fB-s\fR]
 [\fB-a\fR]
-[\fB-t \fItime\fR]
-[\fB-v\fR] [\fB-h\fR] [\fB-V\fR]
-[file]...
+[\fB-t \fItime\fR] [\fB-q \fItime\fR]
+[\fB-l\fR] [\fB-v\fR] [\fB-h\fR] [\fB-V\fR]
+[\fIfile\fR]...
 .SH DESCRIPTION
 Determine the time cron will execute the next job.  Without arguments, it
 prints that time considering all crontabs, in number of seconds since the
@@ -45,6 +45,14 @@ file arguments. This is implicit if no file is passed.
 Determine the next job from this time, instead of now.  The time is
 expressed in number of seconds since the Epoch, as obtained for example by
 .BR "date +%s --date \(dqnow + 2 hours\(dq" .
+.TP
+.BI "\-q " time
+Do not check jobs over this time, expressed in number of seconds since the
+Epoch.
+.TP
+.B \-l
+Print the whole entries of the jobs that are the next to be executed by cron.
+The default is to only print their next time of execution.
 .TP
 .B \-v
 Scanning of the crontab is done in verbose mode.  Each user and job the next

--- a/man/cronnext.1
+++ b/man/cronnext.1
@@ -12,7 +12,8 @@ cronnext \- time of next job cron will execute
 .SH DESCRIPTION
 Determine the time cron will execute the next job.  Without arguments, it
 prints that time considering all crontabs, in number of seconds since the
-Epoch.  This number can be converted into other formats using
+Epoch, rounded to the minute. This number can be converted into other formats
+using
 .BR date (1),
 like
 .B date --date @43243254
@@ -44,11 +45,12 @@ file arguments. This is implicit if no file is passed.
 .BI "\-t " time
 Determine the next job from this time, instead of now.  The time is
 expressed in number of seconds since the Epoch, as obtained for example by
-.BR "date +%s --date \(dqnow + 2 hours\(dq" .
+.BR "date +%s --date \(dqnow + 2 hours\(dq" ,
+and is internally rounded to the minute.
 .TP
 .BI "\-q " time
-Do not check jobs over this time, expressed in number of seconds since the
-Epoch.
+Do not check jobs over this time, expressed in the same way as in option
+.BR -t .
 .TP
 .B \-l
 Print the whole entries of the jobs that are the next to be executed by cron.

--- a/man/cronnext.1
+++ b/man/cronnext.1
@@ -5,9 +5,10 @@ cronnext \- time of next job cron will execute
 .TP 9
 .B cronnext
 [\fB-i \fIusers\fR] [\fB-e \fIusers\fR] [\fB-s\fR]
-[\fB-a \fIfiles\fR]
+[\fB-a\fR]
 [\fB-t \fItime\fR]
 [\fB-v\fR] [\fB-h\fR] [\fB-V\fR]
+[file]...
 .SH DESCRIPTION
 Determine the time cron will execute the next job.  Without arguments, it
 prints that time considering all crontabs, in number of seconds since the
@@ -15,6 +16,10 @@ Epoch.  This number can be converted into other formats using
 .BR date (1),
 like
 .B date --date @43243254
+
+The file arguments are optional. If provided,
+.I cronnext
+uses them as crontabs instead of the ones installed in the system.
 .SH OPTIONS
 .TP
 .BI "\-i " user,user,user,...
@@ -32,11 +37,9 @@ file.  The system crontab usually contains the hourly, daily, weekly and
 montly crontabs, which might be better dealt with
 .BR anacron (8).
 .TP
-.BI "\-a " file,file,file,...
-Read additional crontabs from given files. Each file is considered the crontab
-of a user whose name is the same as the file name. For example, the command to
-analyze the crontab from file "crtab.txt" and not the others is
-.B crontab -a crtab.txt -i crtab.txt
+.BI \-a
+Use the crontabs installed in the system in addition to the ones passed as
+file arguments. This is implicit if no file is passed.
 .TP
 .BI "\-t " time
 Determine the next job from this time, instead of now.  The time is

--- a/man/cronnext.1
+++ b/man/cronnext.1
@@ -4,7 +4,9 @@ cronnext \- time of next job cron will execute
 .SH SYNOPSIS
 .TP 9
 .B cronnext
-[\fB-i \fIusers\fR] [\fB-e \fIusers\fR] [\fB-s\fR] [\fB-t \fItime\fR]
+[\fB-i \fIusers\fR] [\fB-e \fIusers\fR] [\fB-s\fR]
+[\fB-a \fIfiles\fR]
+[\fB-t \fItime\fR]
 [\fB-v\fR] [\fB-h\fR] [\fB-V\fR]
 .SH DESCRIPTION
 Determine the time cron will execute the next job.  Without arguments, it
@@ -24,11 +26,17 @@ for the system crontab.
 Do not consider the crontabs of the specified users.
 .TP
 .B \-s
-Do not consider the system crontab, usually
+Do not consider the system crontab, usually the
 .I /etc/crontab
 file.  The system crontab usually contains the hourly, daily, weekly and
 montly crontabs, which might be better dealt with
 .BR anacron (8).
+.TP
+.BI "\-a " file,file,file,...
+Read additional crontabs from given files. Each file is considered the crontab
+of a user whose name is the same as the file name. For example, the command to
+analyze the crontab from file "crtab.txt" and not the others is
+.B crontab -a crtab.txt -i crtab.txt
 .TP
 .BI "\-t " time
 Determine the next job from this time, instead of now.  The time is

--- a/man/cronnext.1
+++ b/man/cronnext.1
@@ -7,7 +7,7 @@ cronnext \- time of next job cron will execute
 [\fB-i \fIusers\fR] [\fB-e \fIusers\fR] [\fB-s\fR]
 [\fB-a\fR]
 [\fB-t \fItime\fR] [\fB-q \fItime\fR]
-[\fB-l\fR] [\fB-v\fR] [\fB-h\fR] [\fB-V\fR]
+[\fB-l\fR] [\fB-c\fR] [\fB-f\fR] [\fB-h\fR] [\fB-V\fR]
 [\fIfile\fR]...
 .SH DESCRIPTION
 Determine the time cron will execute the next job.  Without arguments, it
@@ -54,10 +54,12 @@ Epoch.
 Print the whole entries of the jobs that are the next to be executed by cron.
 The default is to only print their next time of execution.
 .TP
-.B \-v
-Scanning of the crontab is done in verbose mode.  Each user and job the next
-execution time is printed both as number of seconds since the Epoch and in
-the standard format.
+.B \-c
+Print every entry in every crontab with the next time it is executed.
+.TP
+.B \-f
+Print all jobs that are executed in the given interval. Requires option
+\fB-q\fR.
 .TP
 .B \-h
 Print usage output and exit.

--- a/src/cronnext.c
+++ b/src/cronnext.c
@@ -250,7 +250,7 @@ cron_db database(char *additional) {
 	struct passwd pw;
 	int fd;
 	user *u;
-	char *pos, *saveptr = NULL;
+	char *pos, *saveptr;
 
 	load_database(&db);
 
@@ -306,7 +306,7 @@ int main(int argn, char *argv[]) {
 	exclude = NULL;
 	system = 1;
 	start = time(NULL);
-	char *additional;
+	char *additional = "";
 	verbose = 0;
 
 	cron_db db;

--- a/src/cronnext.c
+++ b/src/cronnext.c
@@ -327,7 +327,7 @@ int main(int argn, char *argv[]) {
 	flags = SYSTEM;
 	endtime = 0;
 	printjobs = 0;
-	start = time(NULL);
+	start = time(NULL) / 60 * 60;
 	int installed = 0;
 
 	cron_db db;
@@ -347,10 +347,10 @@ int main(int argn, char *argv[]) {
 			flags &= ~SYSTEM;
 			break;
 		case 't':
-			start = atoi(optarg);
+			start = atoi(optarg) / 60 * 60;
 			break;
 		case 'q':
-			end = atoi(optarg);
+			end = atoi(optarg) / 60 * 60;
 			endtime = 1;
 			break;
 		case 'l':

--- a/src/cronnext.c
+++ b/src/cronnext.c
@@ -78,11 +78,11 @@ char *flagname[]= {
 	[DONT_LOG] =	"DONT_LOG"
 };
 
-void printflags(int flags) {
+void printflags(char *indent, int flags) {
 	int f;
 	int first = 1;
 
-	printf("flags: 0x%d = ", flags);
+	printf("%s    flagnames:", indent);
 	for (f = 1; f < sizeof(flagname);  f = f << 1)
 		if (flags & f) {
 			printf("%s%s", first ? " " : "|", flagname[f]);
@@ -94,13 +94,14 @@ void printflags(int flags) {
 /*
  * print a crontab entry
  */
-void printentry(entry *e, int system, time_t next) {
-	if (system)
-		printf("entry user: %s\n", e->pwd->pw_name);
-	printf("cmd: %s\n", e->cmd);
-	printflags(e->flags);
-	printf("delay: %d\n", e->delay);
-	printf("next: %ld = ", (long)next);
+void printentry(char *indent, entry *e, time_t next) {
+	printf("%s  - user: %s\n", indent, e->pwd->pw_name);
+	printf("%s    cmd: \"%s\"\n", indent, e->cmd);
+	printf("%s    flags: 0x%02X\n", indent, e->flags);
+	printflags(indent, e->flags);
+	printf("%s    delay: %d\n", indent, e->delay);
+	printf("%s    next: %ld\n", indent, (long)next);
+	printf("%s    nextstring: ", indent);
 	printf("%s", asctime(localtime(&next)));
 }
 
@@ -108,10 +109,10 @@ void printentry(entry *e, int system, time_t next) {
  * print a crontab data
  */
 void printcrontab(user *u) {
-	printf("==========================\n");
-	printf("user: %s\n", u->name);
-	printf("crontab: %s\n", u->tabname);
-	printf("system: %d\n", u->system);
+	printf("  - user: \"%s\"\n", u->name);
+	printf("    crontab: %s\n", u->tabname);
+	printf("    system: %d\n", u->system);
+	printf("    entries:\n");
 }
 
 /*
@@ -218,6 +219,12 @@ time_t cronnext(cron_db database,
 	time_t closest, next;
 	user *u;
 	entry *e;
+	char *indent = "";
+
+	if (verbose & CRONTABS) {
+		printf("crontabs:\n");
+		indent = "    ";
+	}
 
 	/* find next sheduled time */
 	closest = -1;
@@ -239,7 +246,7 @@ time_t cronnext(cron_db database,
 			if ((closest < 0) || (next < closest))
 				closest = next;
 			if (verbose & ENTRIES)
-				printentry(e, u->system, next);
+				printentry(indent, e, next);
 		}
 	}
 
@@ -366,8 +373,8 @@ int main(int argn, char *argv[]) {
 
 	/* debug cron */
 	if (verbose) {
-		printf("SPOOL_DIR=%s\n", SPOOL_DIR);
-		set_debug_flags("load");
+		printf("spool: %s\n", SPOOL_DIR);
+		set_debug_flags("");
 	}
 	/* "load,pars" for debugging loading and parsing, "" for nothing
 	   see globals.h for symbolic names and macros.h for meaning */
@@ -385,7 +392,7 @@ int main(int argn, char *argv[]) {
 		return EXIT_FAILURE;
 	}
 	else if (verbose || printjobs) {
-		printf("next jobs:\n");
+		printf("nextjobs:\n");
 		cronnext(db, next, next, include, exclude, system, ENTRIES);
 	}
 	else

--- a/src/cronnext.c
+++ b/src/cronnext.c
@@ -32,9 +32,11 @@
 #include "funcs.h"
 #include "cron-paths.h"
 
-/* what to print: entries, crontabs, both */
-#define ENTRIES  0x01
-#define CRONTABS 0x02
+/* flags to crontab search */
+#define ENTRIES  0x01			// print entries
+#define CRONTABS 0x02			// print crontabs
+#define SYSTEM   0x04			// include system crontab
+#define ALLJOBS  0x08			// print all jobs in interval
 
 #ifdef WITH_INOTIFY
 void set_cron_watched(int fd) {
@@ -214,17 +216,18 @@ int matchuser(char *user, char *list) {
  */
 time_t cronnext(cron_db database,
 		time_t start, time_t end,
-		char *include, char *exclude, int system,
-		int verbose) {
+		char *include, char *exclude, int flags) {
 	time_t closest, next;
 	user *u;
 	entry *e;
 	char *indent = "";
 
-	if (verbose & CRONTABS) {
+	if (flags & CRONTABS) {
 		printf("crontabs:\n");
 		indent = "    ";
 	}
+	else if (flags & ALLJOBS)
+		printf("jobs:\n");
 
 	/* find next sheduled time */
 	closest = -1;
@@ -233,21 +236,25 @@ time_t cronnext(cron_db database,
 			continue;
 		if (exclude && matchuser(u->name, exclude))
 			continue;
-		if (!system && u->system)
+		if (!(flags & SYSTEM) && u->system)
 			continue;
 
-		if (verbose & CRONTABS)
+		if (flags & CRONTABS)
 			printcrontab(u);
 
-		for (e = u->crontab; e; e = e->next) {
-			next = nextmatch(e, start, end);
-			if (next < 0)
-				continue;
-			if ((closest < 0) || (next < closest))
-				closest = next;
-			if (verbose & ENTRIES)
-				printentry(indent, e, next);
-		}
+		for (e = u->crontab; e; e = e->next)
+			for (next = nextmatch(e, start, end);
+			     next <= end;
+			     next = nextmatch(e, next + 60, end)) {
+				if (next < 0)
+					break;
+				if (closest < 0 || next < closest)
+					closest = next;
+				if (flags & ENTRIES)
+					printentry(indent, e, next);
+				if (! (flags & ALLJOBS))
+					break;
+			}
 	}
 
 	return closest;
@@ -299,7 +306,8 @@ void usage() {
 	fprintf(stderr, " -t time   start from this time (seconds since epoch)\n");
 	fprintf(stderr, " -q time   end check at this time (seconds since epoch)\n");
 	fprintf(stderr, " -l        print next jobs to be executed\n");
-	fprintf(stderr, " -v        verbose mode\n");
+	fprintf(stderr, " -c        print next execution of each job\n");
+	fprintf(stderr, " -f        print all jobs executed in the given interval\n");
 	fprintf(stderr, " -h        this help\n");
 	fprintf(stderr, " -V        print version and exit\n");
 }
@@ -310,21 +318,21 @@ void usage() {
 int main(int argn, char *argv[]) {
 	int opt;
 	char *include, *exclude;
-	int system, verbose, endtime, printjobs;
+	int flags;
 	time_t start, end, next;
+	int endtime, printjobs;
 
 	include = NULL;
 	exclude = NULL;
-	system = 1;
+	flags = SYSTEM;
 	endtime = 0;
 	printjobs = 0;
 	start = time(NULL);
 	int installed = 0;
-	verbose = 0;
 
 	cron_db db;
 
-	while (-1 != (opt = getopt(argn, argv, "i:e:ast:q:lvhV"))) {
+	while (-1 != (opt = getopt(argn, argv, "i:e:ast:q:lcfhV"))) {
 		switch (opt) {
 		case 'i':
 			include = optarg;
@@ -336,7 +344,7 @@ int main(int argn, char *argv[]) {
 			installed = 1;
 			break;
 		case 's':
-			system = 0;
+			flags &= ~SYSTEM;
 			break;
 		case 't':
 			start = atoi(optarg);
@@ -348,8 +356,11 @@ int main(int argn, char *argv[]) {
 		case 'l':
 			printjobs = 1;
 			break;
-		case 'v':
-			verbose = ENTRIES | CRONTABS;
+		case 'c':
+			flags |= ENTRIES | CRONTABS;
+			break;
+		case 'f':
+			flags |= ALLJOBS | ENTRIES;
 			break;
 		case 'h':
 			usage();
@@ -365,6 +376,12 @@ int main(int argn, char *argv[]) {
 		}
 	}
 
+	if (flags & ALLJOBS && !endtime) {
+		fprintf(stderr, "no ending time specified: -f requires -q\n");
+		usage();
+		exit(EXIT_FAILURE);
+	}
+
 	/* maximum match interval is 8 years:
 	 * crontab has '* * 29 2 *' and we are on 1 March 2096:
 	 * next matching time will be 29 February 2104 */
@@ -372,7 +389,7 @@ int main(int argn, char *argv[]) {
 		end = start + 8 * 12 * 31 * 24 * 60 * 60;
 
 	/* debug cron */
-	if (verbose) {
+	if (flags & CRONTABS) {
 		printf("spool: %s\n", SPOOL_DIR);
 		set_debug_flags("");
 	}
@@ -383,20 +400,19 @@ int main(int argn, char *argv[]) {
 	db = database(installed || argv[optind] == NULL, argv + optind);
 
 	/* find time of next scheduled command */
-	next = cronnext(db, start, end, include, exclude, system, verbose);
+	next = cronnext(db, start, end, include, exclude, flags);
 
-	/* print output */
-	if (next == -1) {
-		if (verbose)
-			printf("no job scheduled\n");
+	/* print time */
+	if (next == -1)
 		return EXIT_FAILURE;
-	}
-	else if (verbose || printjobs) {
-		printf("nextjobs:\n");
-		cronnext(db, next, next, include, exclude, system, ENTRIES);
-	}
 	else
-		printf("%ld\n", (long) next);
+		printf("next: %ld\n", (long) next);
+
+	/* print next jobs */
+	if (printjobs) {
+		printf("nextjobs:\n");
+		cronnext(db, next, next, include, exclude, (flags & SYSTEM) | ENTRIES);
+	}
 
 	return EXIT_SUCCESS;
 }

--- a/src/cronnext.c
+++ b/src/cronnext.c
@@ -32,6 +32,10 @@
 #include "funcs.h"
 #include "cron-paths.h"
 
+/* what to print: entries, crontabs, both */
+#define ENTRIES  0x01
+#define CRONTABS 0x02
+
 #ifdef WITH_INOTIFY
 void set_cron_watched(int fd) {
 /* empty stub */
@@ -225,7 +229,7 @@ time_t cronnext(cron_db database,
 		if (!system && u->system)
 			continue;
 
-		if (verbose)
+		if (verbose & CRONTABS)
 			printcrontab(u);
 
 		for (e = u->crontab; e; e = e->next) {
@@ -234,7 +238,7 @@ time_t cronnext(cron_db database,
 				continue;
 			if ((closest < 0) || (next < closest))
 				closest = next;
-			if (verbose)
+			if (verbose & ENTRIES)
 				printentry(e, u->system, next);
 		}
 	}
@@ -287,6 +291,7 @@ void usage() {
 	fprintf(stderr, " -a        examine installed crontabs even if files are given\n");
 	fprintf(stderr, " -t time   start from this time (seconds since epoch)\n");
 	fprintf(stderr, " -q time   end check at this time (seconds since epoch)\n");
+	fprintf(stderr, " -l        print next jobs to be executed\n");
 	fprintf(stderr, " -v        verbose mode\n");
 	fprintf(stderr, " -h        this help\n");
 	fprintf(stderr, " -V        print version and exit\n");
@@ -298,20 +303,21 @@ void usage() {
 int main(int argn, char *argv[]) {
 	int opt;
 	char *include, *exclude;
-	int system, verbose, endtime;
+	int system, verbose, endtime, printjobs;
 	time_t start, end, next;
 
 	include = NULL;
 	exclude = NULL;
 	system = 1;
 	endtime = 0;
+	printjobs = 0;
 	start = time(NULL);
 	int installed = 0;
 	verbose = 0;
 
 	cron_db db;
 
-	while (-1 != (opt = getopt(argn, argv, "i:e:ast:q:vhV"))) {
+	while (-1 != (opt = getopt(argn, argv, "i:e:ast:q:lvhV"))) {
 		switch (opt) {
 		case 'i':
 			include = optarg;
@@ -332,8 +338,11 @@ int main(int argn, char *argv[]) {
 			end = atoi(optarg);
 			endtime = 1;
 			break;
+		case 'l':
+			printjobs = 1;
+			break;
 		case 'v':
-			verbose = 1;
+			verbose = ENTRIES | CRONTABS;
 			break;
 		case 'h':
 			usage();
@@ -366,16 +375,19 @@ int main(int argn, char *argv[]) {
 	/* load database */
 	db = database(installed || argv[optind] == NULL, argv + optind);
 
-	/* print time of next scheduled command */
+	/* find time of next scheduled command */
 	next = cronnext(db, start, end, include, exclude, system, verbose);
+
+	/* print output */
 	if (next == -1) {
 		if (verbose)
 			printf("no job scheduled\n");
 		return EXIT_FAILURE;
 	}
-	else if (verbose)
-		printf("next of all jobs: %ld = %s",
-			(long) next, asctime(localtime(&next)));
+	else if (verbose || printjobs) {
+		printf("next jobs:\n");
+		cronnext(db, next, next, include, exclude, system, ENTRIES);
+	}
 	else
 		printf("%ld\n", (long) next);
 

--- a/src/cronnext.c
+++ b/src/cronnext.c
@@ -76,10 +76,14 @@ char *flagname[]= {
 
 void printflags(int flags) {
 	int f;
+	int first = 1;
+
 	printf("flags: 0x%d = ", flags);
 	for (f = 1; f < sizeof(flagname);  f = f << 1)
-		if (flags & f)
-			printf("%s ", flagname[f]);
+		if (flags & f) {
+			printf("%s%s", first ? " " : "|", flagname[f]);
+			first = 0;
+		}
 	printf("\n");
 }
 


### PR DESCRIPTION
This feature allows for checking when another machine will run its next cron job, like

machine 1: crontab -l > list.txt
copy list.txt from machine1 to machine2
machine 2: cronnext -a list.txt -i list.txt

May also be useful for testing a crontab, for example:

crontab -e
[from the editor, save to a different file test.txt but do not quit]
on another terminal: cronnext -a test.txt
