### PR TITLE
An interactive way to delete

### DIFF
--- a/man/crontab.1
+++ b/man/crontab.1
@@ -33,7 +33,7 @@ crontab \- maintains crontab files for individual users
 .B crontab
 .RB [ -u
 .IR user ]
-.RB [ -l " | " -r " | " -e ]\ [ -i ]
+.RB [ -l " | " -r " | " -e ]
 .RB [ -s ]
 .br
 .B crontab
@@ -123,7 +123,7 @@ command is used under his username.
 Displays the current crontab on standard output.
 .TP
 .B "\-r"
-Removes the current crontab.
+Removes the current crontab with an interactive prompt.
 .TP
 .B "\-e"
 Edits the current crontab using the editor specified by the
@@ -132,12 +132,6 @@ or
 .I EDITOR
 environment variables.  After you exit from the editor, the modified
 crontab will be installed automatically.
-.TP
-.B "\-i"
-This option modifies the
-.B "\-r"
-option to prompt the user for a 'y/Y' response before actually removing
-the crontab.
 .TP
 .B "\-s"
 Appends the current SELinux security context string as an MLS_LEVEL

--- a/src/crontab.c
+++ b/src/crontab.c
@@ -118,7 +118,7 @@ static void usage(const char *msg) {
 	fprintf(stderr, " -u <user>  define user\n");
 	fprintf(stderr, " -e         edit user's crontab\n");
 	fprintf(stderr, " -l         list user's crontab\n");
-	fprintf(stderr, " -d         delete user's crontab\n");
+	fprintf(stderr, " -r         delete user's crontab\n");
 	fprintf(stderr, " -i         prompt before deleting\n");
 	fprintf(stderr, " -n <host>  set host in cluster to run users' crontabs\n");
 	fprintf(stderr, " -c         get host in cluster to run users' crontabs\n");

--- a/src/crontab.c
+++ b/src/crontab.c
@@ -118,7 +118,7 @@ static void usage(const char *msg) {
 	fprintf(stderr, " -u <user>  define user\n");
 	fprintf(stderr, " -e         edit user's crontab\n");
 	fprintf(stderr, " -l         list user's crontab\n");
-	fprintf(stderr, " -r         delete user's crontab\n");
+	fprintf(stderr, " -d         delete user's crontab\n");
 	fprintf(stderr, " -i         prompt before deleting\n");
 	fprintf(stderr, " -n <host>  set host in cluster to run users' crontabs\n");
 	fprintf(stderr, " -c         get host in cluster to run users' crontabs\n");
@@ -272,18 +272,16 @@ static void parse_args(int argc, char *argv[]) {
 				usage("only one operation permitted");
 			Option = opt_list;
 			break;
-		case 'r':
+        case 'r': 
 			if (Option != opt_unknown)
 				usage("only one operation permitted");
-			Option = opt_delete;
+			PromptOnDelete = 1; 
+            Option = opt_delete;
 			break;
 		case 'e':
 			if (Option != opt_unknown)
 				usage("only one operation permitted");
 			Option = opt_edit;
-			break;
-		case 'i':
-			PromptOnDelete = 1;
 			break;
 #ifdef WITH_SELINUX
 		case 's':


### PR DESCRIPTION
Instead of using `-i` as with `-r` for an interactive prompt, you can use only `-r`.

When using the QWERTY layout, the letters *e* and *r* are neighbours and this is dangerous :D