### PR TITLE
Use none-recursive build, and enable anacron by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 Makefile.in
 Makefile
 anacron/anacron
-anacron/anacron-paths.h
+anacron-paths.h
 anacron/Makefile
 anacron/Makefile.in
 aclocal.m4
@@ -26,8 +26,9 @@ tags
 src/crond
 src/crontab
 src/cronnext
-src/cron-paths.h
+cron-paths.h
 *~
 *.tar.*
 *.orig
 *.patch
+.dirstamp

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,16 @@
-SUBDIRS = src man anacron
+AM_CFLAGS = -I$(top_srcdir)
+
+BUILT_SOURCES =
+CLEANFILES =
+EXTRA_DIST =
+bin_PROGRAMS =
+common_nodist =
+sbin_PROGRAMS =
 
 dist_noinst_HEADERS = \
 	cronie_common.h
 
-EXTRA_DIST = \
+EXTRA_DIST += \
 	cronie.init \
 	crond.sysconfig \
 	contrib/anacrontab \
@@ -19,3 +26,7 @@ dist_pam_DATA = pam/crond
 else
 EXTRA_DIST += pam/crond
 endif
+
+include anacron/Makemodule.am
+include man/Makemodule.am
+include src/Makemodule.am

--- a/anacron/Makemodule.am
+++ b/anacron/Makemodule.am
@@ -1,23 +1,28 @@
 # Makefile.am - two binaries crond and crontab
 if ANACRON
-sbin_PROGRAMS = anacron
-endif
+sbin_PROGRAMS += anacron/anacron
+anacron_anacron_SOURCES = \
+	anacron-paths.h \
+	anacron/global.h \
+	anacron/gregor.c \
+	anacron/gregor.h \
+	anacron/lock.c \
+	anacron/log.c \
+	anacron/main.c \
+	anacron/matchrx.c \
+	anacron/matchrx.h \
+	anacron/readtab.c \
+	anacron/runjob.c
+common_nodist += anacron-paths.h
+nodist_anacron_anacron_SOURCES = $(common_nodist)
+BUILT_SOURCES += $(common_nodist)
 
-anacron_SOURCES = \
-  gregor.c lock.c log.c main.c matchrx.c readtab.c runjob.c \
-  $(common_src)
-common_src = global.h gregor.h matchrx.h
-common_nodist = anacron-paths.h
-nodist_anacron_SOURCES = $(common_nodist)
-BUILT_SOURCES = $(common_nodist)
-
-AM_CFLAGS = -I$(top_srcdir)
-
-LDADD = $(LIBSELINUX) $(LIBPAM) $(LIBAUDIT)
+anacron_anacron_LDADD = $(LIBSELINUX) $(LIBPAM) $(LIBAUDIT)
 
 # This header contains all the paths.
 # If they are configurable, they are declared in configure script.
 # Depends on this Makefile, because it uses make variables.
+CLEANFILES += anacron-paths.h
 anacron-paths.h: Makefile
 	@echo 'creating $@'
 	@sed >$@ 's/ *\\$$//' <<\END #\
@@ -29,3 +34,4 @@ anacron-paths.h: Makefile
 	#define ANACRONTAB "$(ANACRONTAB)" \
 	#endif /* _ANACRON_PATHS_H_ */ \
 	END
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_INIT([cronie],[1.5.4],[mmaslano@redhat.com,tmraz@fedoraproject.org])
 AC_CONFIG_HEADER([config.h])
 AC_PREREQ(2.60)
 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])],
 			    [AC_SUBST([AM_DEFAULT_VERBOSITY], [1])])
@@ -260,6 +260,6 @@ if test "$enable_anacron" != no; then
 	ANACRON_CONF_VAR([ANACRONTAB],[The anacron table for regular jobs.],[${sysconfdir}/anacrontab])
 fi
 
-AC_CONFIG_FILES([Makefile src/Makefile man/Makefile anacron/Makefile])
+AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -253,7 +253,7 @@ CRONIE_CONF_VAR([SYSCRONTAB], [the current working directory of the running daem
 CRONIE_CONF_VAR([SYS_CROND_DIR], [the current working directory of the running daemon], [${sysconfdir}/cron.d])
 CRONIE_CONF_VAR([SPOOL_DIR], [the directory where all the user cron tabs reside], [${localstatedir}/spool/cron])
 
-AC_ARG_ENABLE([anacron], [AS_HELP_STRING([--enable-anacron], [Build also anacron.])])
+AC_ARG_ENABLE([anacron], [AS_HELP_STRING([--disable-anacron], [Do not build anacron.])], [], [enable_anacron=yes])
 AM_CONDITIONAL([ANACRON], [test "$enable_anacron" = yes])
 if test "$enable_anacron" != no; then
 	ANACRON_CONF_VAR([ANACRON_SPOOL_DIR],[The path for anacron locks.],[${localstatedir}/spool/anacron])

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,6 +1,0 @@
-dist_man_MANS = crontab.1 crontab.5 cron.8 crond.8 cronnext.1
-EXTRA_DIST = anacrontab.5 anacron.8
-
-if ANACRON
-dist_man_MANS += $(EXTRA_DIST)
-endif

--- a/man/Makemodule.am
+++ b/man/Makemodule.am
@@ -1,0 +1,16 @@
+dist_man_MANS = \
+	man/cron.8 \
+	man/crond.8 \
+	man/cronnext.1 \
+	man/crontab.1 \
+	man/crontab.5
+
+anacron_man = \
+	man/anacrontab.5 \
+	man/anacron.8
+
+EXTRA_DIST += $(anacron_man)
+
+if ANACRON
+dist_man_MANS += $(anacron_man)
+endif

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -1,27 +1,55 @@
 # Makefile.am - two binaries crond and crontab
 
-sbin_PROGRAMS = crond
-bin_PROGRAMS = crontab cronnext
+sbin_PROGRAMS += \
+	src/crond
 
-crond_SOURCES = \
-	cron.c database.c user.c job.c do_command.c popen.c security.c \
+bin_PROGRAMS += \
+	src/cronnext \
+	src/crontab
+
+src_crond_SOURCES = \
+	src/cron.c \
+	src/database.c \
+	src/do_command.c \
+	src/job.c \
+	src/popen.c \
+	src/security.c \
+	src/user.c \
 	$(common_src)
-crontab_SOURCES = crontab.c security.c $(common_src)
-cronnext_SOURCES = \
-	cronnext.c database.c user.c job.c \
+
+src_crontab_SOURCES = \
+	src/crontab.c \
+	src/security.c \
 	$(common_src)
-common_src = entry.c env.c misc.c pw_dup.c \
-	externs.h funcs.h globals.h macros.h pathnames.h structs.h \
-	bitstring.h
-common_nodist = cron-paths.h
-nodist_crond_SOURCES = $(common_nodist)
-nodist_crontab_SOURCES = $(common_nodist)
-nodist_cronnext_SOURCES = $(common_nodist)
-BUILT_SOURCES = $(common_nodist)
 
-AM_CFLAGS = -I$(top_srcdir)
+src_cronnext_SOURCES = \
+	src/cronnext.c \
+	src/database.c \
+	src/job.c \
+	src/user.c \
+	$(common_src)
 
-LDADD = $(LIBSELINUX) $(LIBPAM) $(LIBAUDIT)
+common_src = \
+	src/bitstring.h \
+	src/entry.c \
+	src/env.c \
+	src/externs.h \
+	src/funcs.h \
+	src/globals.h \
+	src/macros.h \
+	src/misc.c \
+	src/pathnames.h \
+	src/pw_dup.c \
+	src/structs.h
+
+common_nodist += cron-paths.h
+nodist_src_crond_SOURCES = $(common_nodist)
+nodist_src_crontab_SOURCES = $(common_nodist)
+nodist_src_cronnext_SOURCES = $(common_nodist)
+BUILT_SOURCES += $(common_nodist)
+
+src_crond_LDADD = $(LIBSELINUX) $(LIBPAM) $(LIBAUDIT)
+src_crontab_LDADD = $(LIBSELINUX) $(LIBPAM) $(LIBAUDIT)
 
 ## if DEBUG
 ## noinst_PROGRAMS = debug
@@ -31,7 +59,7 @@ LDADD = $(LIBSELINUX) $(LIBPAM) $(LIBAUDIT)
 # If they are configurable, they are declared in configure script.
 # Depends on this Makefile, because it uses make variables.
 # CCD 2010/09/10 added CRON_HOSTNAME for clustered-cron.
-CLEANFILES = cron-paths.h
+CLEANFILES += cron-paths.h
 cron-paths.h: Makefile
 	@echo 'creating $@'
 	@sed >$@ 's/ *\\$$//' <<\END #\


### PR DESCRIPTION
This pull request contains two last  commits from earlier pull[1] that was requested to be split. That is now done, as well as rebase on top of most recent origin/master.

[1] https://github.com/cronie-crond/cronie/pull/10
