### PR TITLE
Don't allow cron to start manually

### DIFF
--- a/contrib/cronie.systemd
+++ b/contrib/cronie.systemd
@@ -4,11 +4,13 @@ After=auditd.service nss-user-lookup.target systemd-user-sessions.service time-s
 
 [Service]
 EnvironmentFile=/etc/sysconfig/crond
-ExecStart=/usr/sbin/crond -n $CRONDARGS
+ExecStart=/usr/sbin/crond $CRONDARGS
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure
 RestartSec=30s
+PIDFile=/var/run/cron.pid
+Type=forking
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Dears, 
Above changes will make sure cron doesn't start manually. Below is an example: 

s12sp4:~ # systemctl start cron
s12sp4:~ # systemctl status cron 
● cron.service - Command Scheduler
   Loaded: loaded (/usr/lib/systemd/system/cron.service; enabled; vendor preset: enabled)
   Active: active (running) since Tue 2019-04-23 13:54:00 CEST; 4s ago
 Main PID: 3564 (cron)
    Tasks: 1 (limit: 512)
   CGroup: /system.slice/cron.service
           └─3564 /usr/sbin/cron -n

Apr 23 13:54:00 s12sp4 systemd[1]: Started Command Scheduler.
Apr 23 13:54:00 s12sp4 cron[3564]: (CRON) INFO (RANDOM_DELAY will be scaled with factor 88% if used.)
Apr 23 13:54:00 s12sp4 cron[3564]: (CRON) INFO (running with inotify support)
Apr 23 13:54:00 s12sp4 cron[3564]: (CRON) INFO (@reboot jobs will be run at computer's startup.)
s12sp4:~ # ll /var/run/cro*
---------- 1 root root 0 Apr 23 13:41 /var/run/cron.reboot
s12sp4:~ # 
s12sp4:~ # ps -ef |grep cron
root      3564     1  0 13:53 ?        00:00:00 /usr/sbin/cron -n
root      3570 30890  0 13:54 pts/0    00:00:00 grep --color=auto cron
s12sp4:~ # cron
s12sp4:~ # ps -ef |grep cron
root      3564     1  0 13:53 ?        00:00:00 /usr/sbin/cron -n
root      3572     1  0 13:54 ?        00:00:00 cron
root      3574 30890  0 13:54 pts/0    00:00:00 grep --color=auto cron
s12sp4:~ # ll /var/run/cro*
-rw-r--r-- 1 root root 5 Apr 23 13:54 /var/run/cron.pid
---------- 1 root root 0 Apr 23 13:41 /var/run/cron.reboot
s12sp4:~ # cat /var/run/cron.pid
3572


---- To fix : 

cp -p /usr/lib/systemd/system/cron.service /etc/systemd/system/cron.service 

s12sp4:~ # vi /etc/systemd/system/cron.service
s12sp4:~ # cat /etc/systemd/system/cron.service
[Unit]
Description=Command Scheduler
After=ypbind.service nscd.service network.target
After=postfix.service sendmail.service exim.service

[Service]
ExecStart=/usr/sbin/cron
ExecReload=/usr/bin/kill -s SIGHUP $MAINPID
Restart=on-abort
PIDFile=/var/run/cron.pid
Type=forking

[Install]
WantedBy=multi-user.target

s12sp4:~ # systemctl daemon-reload 
s12sp4:~ # systemctl start cron
s12sp4:~ # ll /var/run/cr*
-rw-r--r-- 1 root root 5 Apr 23 13:59 /var/run/cron.pid
---------- 1 root root 0 Apr 23 13:59 /var/run/cron.reboot
s12sp4:~ # cron
cron: can't lock /run/cron.pid, otherpid may be 3660: Resource temporarily unavailable
s12sp4:~ #