### PR TITLE
Power supply name not detected correctly.

### DIFF
--- a/contrib/0anacron
+++ b/contrib/0anacron
@@ -9,7 +9,7 @@ fi
 
 # Do not run jobs when on battery power
 online=1
-for psupply in AC ADP0 ; do
+for psupply in AC ADP{0..9} ; do
     sysfile="/sys/class/power_supply/$psupply/online"
 
     if [ -f $sysfile ] ; then


### PR DESCRIPTION
Use a number range to detect ADP names rather than just 'ADP0'. On my laptop the name 'ADP1' is used.