### PR TITLE
crontab -l colors comment lines in a different color

### DIFF
--- a/src/crontab.c
+++ b/src/crontab.c
@@ -66,6 +66,9 @@
 
 #define NHEADER_LINES 0
 
+#define COMMENT_COLOR  "\x1B[34m"
+#define RESET_COLOR "\033[0m"
+
 enum opt_t {opt_unknown, opt_list, opt_delete, opt_edit, opt_replace, opt_hostset, opt_hostget};
 
 #if DEBUGGING
@@ -392,6 +395,7 @@ static void list_cmd(void) {
 	char n[MAX_FNAME];
 	FILE *f;
 	int ch;
+	int new_line = 1;
 
 	log_it(RealUser, Pid, "LIST", User, 0);
 	if (!glue_strings(n, sizeof n, SPOOL_DIR, User, '/')) {
@@ -409,8 +413,17 @@ static void list_cmd(void) {
 	/* file is open. copy to stdout, close.
 	 */
 	Set_LineNum(1)
-		while (EOF != (ch = get_char(f)))
+	while (EOF != (ch = get_char(f))){
+		if(new_line){
+			if(ch == '#' && isatty(STDOUT)){
+				printf(COMMENT_COLOR);
+			}else{
+				printf(RESET_COLOR);
+			}
+		}
 		putchar(ch);
+		new_line = ch == '\n';
+	}
 	fclose(f);
 }
 

--- a/src/crontab.c
+++ b/src/crontab.c
@@ -416,10 +416,10 @@ static void list_cmd(void) {
 	while (EOF != (ch = get_char(f))) {
 		if (new_line) {
 			if (ch == '#' && isatty(STDOUT)) {
-				printf(COMMENT_COLOR);
+				fputs(COMMENT_COLOR, stdout);
 			}
 			else {
-				printf(RESET_COLOR);
+				fputs(RESET_COLOR, stdout);
 			}
 		}
 		putchar(ch);

--- a/src/crontab.c
+++ b/src/crontab.c
@@ -395,6 +395,7 @@ static void list_cmd(void) {
 	char n[MAX_FNAME];
 	FILE *f;
 	int ch;
+	const int is_tty = isatty(STDOUT);
 	int new_line = 1;
 
 	log_it(RealUser, Pid, "LIST", User, 0);
@@ -414,8 +415,8 @@ static void list_cmd(void) {
 	 */
 	Set_LineNum(1)
 	while (EOF != (ch = get_char(f))) {
-		if (new_line) {
-			if (ch == '#' && isatty(STDOUT)) {
+		if (is_tty && new_line) {
+			if (ch == '#') {
 				fputs(COMMENT_COLOR, stdout);
 			}
 			else {

--- a/src/crontab.c
+++ b/src/crontab.c
@@ -413,11 +413,12 @@ static void list_cmd(void) {
 	/* file is open. copy to stdout, close.
 	 */
 	Set_LineNum(1)
-	while (EOF != (ch = get_char(f))){
-		if(new_line){
-			if(ch == '#' && isatty(STDOUT)){
+	while (EOF != (ch = get_char(f))) {
+		if (new_line) {
+			if (ch == '#' && isatty(STDOUT)) {
 				printf(COMMENT_COLOR);
-			}else{
+			}
+			else {
 				printf(RESET_COLOR);
 			}
 		}


### PR DESCRIPTION
It would be useful to display the tasks displayed in a terminal by
`crontab -l` with color.

In my opinion, providing a color for comment is enough. More would be
better but less important. I prefer to show this first PR and get your feedback before going further.

My use case is when there are several tasks and one of them is commented
(# is the first character of the line). Sometime, you can waste time
before noticing it:
```
# m h  dom mon dow   command
53 0 * * * cd /tmp/tmp.a3LS17Jgba; touch demo.txt
#3 10 * * * ls /home/stephane
44 20 * * * date > tmp/tmp.a3LS17Jgba/demo.txt
```

This patch is directly adapted from a previous one, sent to Debian (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=813614).