### PR TITLE
do not log carriage return

### DIFF
--- a/src/do_command.c
+++ b/src/do_command.c
@@ -506,6 +506,8 @@ static int child_process(entry * e, char **jobenv) {
 			 */
 
 			while (EOF != (ch = getc(in))) {
+				if (ch == '\r')
+					continue;
 				bytes++;
 				if (mail)
 					putc(ch, mail);


### PR DESCRIPTION
Some commands (like ssh) end their output with carriage return (\r) and
new line (\n). Just cutting the new line before sending to syslog may
have undesired effects of unprintable characters. Reading cronie logs
with journalctl I can see:

Sep 06 16:50:01 linux CROND[152575]: [96B blob data]

Adding switch --all for unprintable characters it shows:

Sep 06 16:50:01 linux CROND[152575]: (root) CMDOUT (Warning: Permanently
added '10.52.33.217' (ED25519) to the list of known hosts.^M)

Just skip carriage return for syslog to prevent this.