### PR TITLE
Fix #45: color is reset properly if crontab ends with a comment

### DIFF
--- a/src/crontab.c
+++ b/src/crontab.c
@@ -426,6 +426,7 @@ static void list_cmd(void) {
 		putchar(ch);
 		new_line = ch == '\n';
 	}
+	fputs(RESET_COLOR, stdout);
 	fclose(f);
 }
 


### PR DESCRIPTION
Adds the color reset escape sequence (`\033[0m`) to the end of the output for `crontab -l` to prevent issue #45 from happening.