### PR TITLE
Fix incorrect include of fcntl.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,6 @@ AC_CHECK_HEADERS( \
         sys/timers.h \
         sys/types.h \
         sys/cdefs.h \
-        sys/fcntl.h \
         time.h \
         unistd.h \
         util.h \

--- a/src/cron.c
+++ b/src/cron.c
@@ -40,13 +40,10 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <fcntl.h>
 
 #ifdef WITH_INOTIFY
 # include <sys/inotify.h>
-#endif
-
-#ifdef HAVE_SYS_FCNTL_H
-# include <sys/fcntl.h>
 #endif
 
 #include "cronie_common.h"


### PR DESCRIPTION
During compilation cronie, I have noticed this warning:

`In file included from src/cron.c:49:0: warning: #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h> [-Wcpp].`

It is trivial to fix. 
Compile tested and run tested on OpenWrt.