### PR TITLE
Allow backslashes when not part of a line continuation

### DIFF
--- a/anacron/readtab.c
+++ b/anacron/readtab.c
@@ -98,7 +98,7 @@ Return NULL if no more lines.
 	    break;
 	}
 
-	if ('\\' != prev && 0 != prev && '\n' != prev) obstack_1grow(&input_o, (char)prev);
+	if (('\\' != prev || c != '\n') && 0 != prev && '\n' != prev) obstack_1grow(&input_o, (char)prev);
 	else if ('\n' == prev) obstack_1grow(&input_o, ' ');
 
 	prev = c;


### PR DESCRIPTION
Fix for #54 

Backslashes were previously skipped over and only considered as part of dealing with line continuation. But many commands rely on them such as find and we should be able to use them. Now we add them to input unless they are at the end of a line.