### PR TITLE
Add CMDEND log entry to log when cron jobs end.

### DIFF
--- a/src/do_command.c
+++ b/src/do_command.c
@@ -581,6 +581,14 @@ static int child_process(entry * e, char **jobenv) {
 			Debug(DPROC,
 				("[%ld] no more grandchildren--mail written?\n",
 					(long) getpid()));
+
+			if ((e->flags & DONT_LOG) == 0) {
+				char *x = mkprints((u_char *) e->cmd, strlen(e->cmd));
+
+				log_it(usernm, getpid(), "CMDEND", x, 0);
+				free(x);
+			}
+
 			break;
 		}
 		Debug(DPROC, ("[%ld] grandchild #%ld finished, status=%04x",

--- a/src/do_command.c
+++ b/src/do_command.c
@@ -592,7 +592,7 @@ static int child_process(entry * e, char **jobenv) {
 	if ((e->flags & DONT_LOG) == 0) {
 		char *x = mkprints((u_char *) e->cmd, strlen(e->cmd));
 
-		log_it(usernm, getpid(), "CMDEND", x, 0);
+		log_it(usernm, getpid(), "CMDEND", x ? x : "Unknown command" , 0);
 		free(x);
 	}
 	return OK_EXIT;

--- a/src/do_command.c
+++ b/src/do_command.c
@@ -581,14 +581,6 @@ static int child_process(entry * e, char **jobenv) {
 			Debug(DPROC,
 				("[%ld] no more grandchildren--mail written?\n",
 					(long) getpid()));
-
-			if ((e->flags & DONT_LOG) == 0) {
-				char *x = mkprints((u_char *) e->cmd, strlen(e->cmd));
-
-				log_it(usernm, getpid(), "CMDEND", x, 0);
-				free(x);
-			}
-
 			break;
 		}
 		Debug(DPROC, ("[%ld] grandchild #%ld finished, status=%04x",
@@ -596,6 +588,12 @@ static int child_process(entry * e, char **jobenv) {
 			if (WIFSIGNALED(waiter) && WCOREDUMP(waiter))
 				Debug(DPROC, (", dumped core"));
 			Debug(DPROC, ("\n"));
+	}
+	if ((e->flags & DONT_LOG) == 0) {
+		char *x = mkprints((u_char *) e->cmd, strlen(e->cmd));
+
+		log_it(usernm, getpid(), "CMDEND", x, 0);
+		free(x);
 	}
 	return OK_EXIT;
 }


### PR DESCRIPTION
Sorry for the delay, but I finally got round to this! (Issue #48)
Ran through a few versions, but this final effort, despite being a relatively simple change to the code, seems to work okay. I wanted to include the job PID in the CMDEND message, and that could be done for some jobs but not all. It seemed best to be consistent, and so not include the PID.
One possible issue is that the same cron job run at different times could be confusing - e.g if the crontab contains:
`* * * * * date`
`*/2 * * * * date`
The log file will just record the command 'date', but the user would have to work out which cron job is being referred to.

Anyway, I'm submitting this PR for your consideration, but feel free to modify it or reject it.
