### PR TITLE
Add new option to test a crontab file syntax without installing it

### DIFF
--- a/man/crontab.1
+++ b/man/crontab.1
@@ -33,6 +33,11 @@ crontab \- maintains crontab files for individual users
 .RB | \ - >
 .br
 .B crontab
+.RB [ -T ]
+.RI < "file"
+.RB | \ - >
+.br
+.B crontab
 .RB [ -u
 .IR user ]
 .RB < -l " | " -r " | " -e >\ [ -i ]
@@ -120,6 +125,10 @@ command. If no crontab exists for a particular user, it is created for
 them the first time the
 .B crontab -u
 command is used under their username.
+.TP
+.B "\-T"
+Test the crontab file syntax without installing it. 
+Once an issue is found, the validation is interrupted, so this will not return all the existing issues at the same execution.
 .TP
 .B "\-l"
 Displays the current crontab on standard output.

--- a/man/crontab.5
+++ b/man/crontab.5
@@ -235,6 +235,10 @@ field matches the current time.  For example,
 .br
 "30 4 1,15 * 5" would cause a command to be run at 4:30 am on the 1st and
 15th of each month, plus every Friday.
+.PP
+A crontab file syntax can be tested before an install using the -T option. See
+.BR crontab (1)
+for details.
 .SH EXAMPLE CRON FILE
 .nf
 # use /bin/sh to run commands, no matter what /etc/passwd says

--- a/src/crontab.c
+++ b/src/crontab.c
@@ -70,14 +70,14 @@
 #define ERROR_COLOR "\x1B[31m"
 #define RESET_COLOR "\x1B[0m"
 
-enum opt_t { opt_unknown, opt_list, opt_delete, opt_edit, opt_replace,
-	opt_hostset, opt_hostget, opt_test
+enum opt_t {
+	opt_unknown, opt_list, opt_delete, opt_edit, opt_replace, opt_hostset,
+	opt_hostget, opt_test
 };
 
 #if DEBUGGING
-static const char *Options[] =
-	{ "???", "list", "delete", "edit", "replace", "hostset", "hostget",
-	"test"
+static const char *Options[] = {
+	"???", "list", "delete", "edit", "replace", "hostset", "hostget", "test"
 };
 
 # ifdef WITH_SELINUX
@@ -112,14 +112,14 @@ edit_cmd(void),
 poke_daemon(void),
 check_error(const char *), parse_args(int c, char *v[]),
 die(int) ATTRIBUTE_NORETURN;
-	 static int replace_cmd(void), hostset_cmd(void), hostget_cmd(void),
-	test_cmd(void), check_syntax(FILE *);
-	 static char *host_specific_filename(const char *prefix,
-	const char *suffix);
-	 static const char *tmp_path(void);
+static int replace_cmd(void), hostset_cmd(void), hostget_cmd(void),
+test_cmd(void), check_syntax(FILE *);
+static char *host_specific_filename(const char *prefix,
+const char *suffix);
+static const char *tmp_path(void);
 
-	 static void usage(const char *msg) ATTRIBUTE_NORETURN;
-	 static void usage(const char *msg) {
+static void usage(const char *msg) ATTRIBUTE_NORETURN;
+static void usage(const char *msg) {
 	fprintf(stderr, "%s: usage error: %s\n", ProgramName, msg);
 	fprintf(stderr, "Usage:\n");
 	fprintf(stderr, " %s [options] file\n", ProgramName);
@@ -144,7 +144,7 @@ die(int) ATTRIBUTE_NORETURN;
 #endif
 	fprintf(stderr, "\nDefault operation is replace, per 1003.2\n");
 	exit(ERROR_EXIT);
-	 }
+}
 
 int main(int argc, char *argv[]) {
 	int exitstatus;
@@ -872,17 +872,17 @@ static int replace_cmd(void) {
 	}
 
 	file_owner = (getgid() == geteuid() &&
-		getgid() == getegid())? ROOT_UID : pw->pw_uid;
+		getgid() == getegid()) ? ROOT_UID : pw->pw_uid;
 
 #ifdef HAVE_FCHOWN
-	if (fchown(fileno(tmp), file_owner, (gid_t) - 1) < OK) {
+	if (fchown(fileno(tmp), file_owner, (gid_t)-1) < OK) {
 		perror("fchown");
 		fclose(tmp);
 		error = -2;
 		goto done;
 	}
 #else
-	if (chown(TempFilename, file_owner, (gid_t) - 1) < OK) {
+	if (chown(TempFilename, file_owner, (gid_t)-1) < OK) {
 		perror("chown");
 		fclose(tmp);
 		error = -2;
@@ -935,8 +935,8 @@ static int check_syntax(FILE * crontab_file) {
 	char **envp = env_init();
 	int eof = FALSE;
 	int envs = 0, entries = 0;
+	
 	CheckErrorCount = 0;
-
 	Set_LineNum(1 - NHEADER_LINES);
 
 	if (envp == NULL) {

--- a/src/crontab.c
+++ b/src/crontab.c
@@ -70,10 +70,15 @@
 #define ERROR_COLOR "\x1B[31m"
 #define RESET_COLOR "\x1B[0m"
 
-enum opt_t {opt_unknown, opt_list, opt_delete, opt_edit, opt_replace, opt_hostset, opt_hostget, opt_test};
+enum opt_t { opt_unknown, opt_list, opt_delete, opt_edit, opt_replace,
+	opt_hostset, opt_hostget, opt_test
+};
 
 #if DEBUGGING
-static const char *Options[] = {"???", "list", "delete", "edit", "replace", "hostset", "hostget", "test"};
+static const char *Options[] =
+	{ "???", "list", "delete", "edit", "replace", "hostset", "hostget",
+	"test"
+};
 
 # ifdef WITH_SELINUX
 static const char *getoptargs = "u:lerisncx:VT";
@@ -105,13 +110,16 @@ static void list_cmd(void),
 delete_cmd(void),
 edit_cmd(void),
 poke_daemon(void),
-check_error(const char *), parse_args(int c, char *v[]), die(int) ATTRIBUTE_NORETURN;
-static int replace_cmd(void), hostset_cmd(void), hostget_cmd(void), test_cmd(void), check_syntax(FILE *);
-static char *host_specific_filename(const char *prefix, const char *suffix);
-static const char *tmp_path(void);
+check_error(const char *), parse_args(int c, char *v[]),
+die(int) ATTRIBUTE_NORETURN;
+	 static int replace_cmd(void), hostset_cmd(void), hostget_cmd(void),
+	test_cmd(void), check_syntax(FILE *);
+	 static char *host_specific_filename(const char *prefix,
+	const char *suffix);
+	 static const char *tmp_path(void);
 
-static void usage(const char *msg) ATTRIBUTE_NORETURN;
-static void usage(const char *msg) {
+	 static void usage(const char *msg) ATTRIBUTE_NORETURN;
+	 static void usage(const char *msg) {
 	fprintf(stderr, "%s: usage error: %s\n", ProgramName, msg);
 	fprintf(stderr, "Usage:\n");
 	fprintf(stderr, " %s [options] file\n", ProgramName);
@@ -136,12 +144,12 @@ static void usage(const char *msg) {
 #endif
 	fprintf(stderr, "\nDefault operation is replace, per 1003.2\n");
 	exit(ERROR_EXIT);
-}
+	 }
 
 int main(int argc, char *argv[]) {
 	int exitstatus;
 
-	if ((ProgramName=strrchr(argv[0], '/')) == NULL) {
+	if ((ProgramName = strrchr(argv[0], '/')) == NULL) {
 		ProgramName = argv[0];
 	}
 	else {
@@ -203,10 +211,10 @@ int main(int argc, char *argv[]) {
 		if (hostget_cmd() < 0)
 			exitstatus = ERROR_EXIT;
 		break;
-    case opt_test:
-        if (test_cmd() < 0)
+	case opt_test:
+		if (test_cmd() < 0)
 			exitstatus = ERROR_EXIT;
-		break;        
+		break;
 	default:
 		abort();
 	}
@@ -255,9 +263,9 @@ static void parse_args(int argc, char *argv[]) {
 				exit(ERROR_EXIT);
 			}
 #endif
-			if (Option == opt_hostset || Option == opt_hostget || Option == opt_test) {
-				fprintf(stderr,
-					"cannot use -u with -n, -c or -T\n");
+			if (Option == opt_hostset || Option == opt_hostget ||
+				Option == opt_test) {
+				fprintf(stderr, "cannot use -u with -n, -c or -T\n");
 				exit(ERROR_EXIT);
 			}
 
@@ -303,15 +311,13 @@ static void parse_args(int argc, char *argv[]) {
 #endif
 		case 'n':
 			if (MY_UID(pw) != ROOT_UID) {
-				fprintf(stderr,
-					"must be privileged to set host with -n\n");
+				fprintf(stderr, "must be privileged to set host with -n\n");
 				exit(ERROR_EXIT);
 			}
 			if (Option != opt_unknown)
 				usage("only one operation permitted");
 			if (strcmp(User, RealUser) != 0) {
-				fprintf(stderr,
-					"cannot use -u with -n or -c\n");
+				fprintf(stderr, "cannot use -u with -n or -c\n");
 				exit(ERROR_EXIT);
 			}
 			Option = opt_hostset;
@@ -320,8 +326,7 @@ static void parse_args(int argc, char *argv[]) {
 			if (Option != opt_unknown)
 				usage("only one operation permitted");
 			if (strcmp(User, RealUser) != 0) {
-				fprintf(stderr,
-					"cannot use -u with -n or -c\n");
+				fprintf(stderr, "cannot use -u with -n or -c\n");
 				exit(ERROR_EXIT);
 			}
 			Option = opt_hostget;
@@ -343,13 +348,13 @@ static void parse_args(int argc, char *argv[]) {
 		(void) strcpy(Host, argv[optind]);
 		optind++;
 	}
-	
-	if(Option == opt_unknown) {
-	    /* replace is the default option */
-	    Option = opt_replace;
+
+	if (Option == opt_unknown) {
+		/* replace is the default option */
+		Option = opt_replace;
 	}
-	
-	if(Option == opt_replace || Option == opt_test) {
+
+	if (Option == opt_replace || Option == opt_test) {
 		if (argv[optind] != NULL) {
 			if (strlen(argv[optind]) >= sizeof Filename)
 				usage("filename too long");
@@ -357,14 +362,14 @@ static void parse_args(int argc, char *argv[]) {
 			optind++;
 		}
 		else
-			usage("file name or - (for stdin) must be specified for this option");
+			usage("file name or - (for stdin) must be specified");
 	}
 
 	if (Option != opt_unknown && argv[optind] != NULL) {
 		usage("no arguments permitted after this option");
 	}
 
-	if (Filename != NULL) {
+	if (Filename[0] != '\0') {
 		if (!strcmp(Filename, "-"))
 			NewCrontab = stdin;
 		else {
@@ -391,8 +396,7 @@ static void parse_args(int argc, char *argv[]) {
 			}
 			if ((sb.st_mode & S_IFMT) == S_IFDIR) {
 				fprintf(stderr,
-					"invalid crontab file: '%s' is a directory\n",
-					Filename);
+					"invalid crontab file: '%s' is a directory\n", Filename);
 				fclose(NewCrontab);
 				exit(ERROR_EXIT);
 			}
@@ -430,7 +434,7 @@ static void list_cmd(void) {
 
 	/* file is open. copy to stdout, close.
 	 */
-	Set_LineNum(1)
+	Set_LineNum(1);
 	while (EOF != (ch = get_char(f))) {
 		if (is_tty) {
 			if (!in_comment && new_line && ch == '#') {
@@ -449,7 +453,7 @@ static void list_cmd(void) {
 	if (is_tty && !new_line) {
 		putchar('\n');
 		fputs(ERROR_COLOR "No end-of-line character at the end of file"
-		      RESET_COLOR, stdout);
+			RESET_COLOR, stdout);
 		putchar('\n');
 	}
 	fclose(f);
@@ -495,8 +499,7 @@ static const char *tmp_path(void) {
 	return tmpdir ? tmpdir : "/tmp";
 }
 
-static char *host_specific_filename(const char *prefix, const char *suffix)
-{
+static char *host_specific_filename(const char *prefix, const char *suffix) {
 	/*
 	 * For cluster-wide use, where there is otherwise risk of the same
 	 * name being generated on more than one host at once, insert hostname
@@ -577,14 +580,14 @@ static void edit_cmd(void) {
 		goto fatal;
 	}
 
-	Set_LineNum(1)
-		/* 
-		 * NHEADER_LINES processing removed for clarity
-		 * (NHEADER_LINES == 0 in all Red Hat crontabs)
-		 */
-		/* copy the rest of the crontab (if any) to the temp file.
-		 */
-		if (EOF != ch)
+	Set_LineNum(1);
+	/* 
+	 * NHEADER_LINES processing removed for clarity
+	 * (NHEADER_LINES == 0 in all Red Hat crontabs)
+	 */
+	/* copy the rest of the crontab (if any) to the temp file.
+	 */
+	if (EOF != ch)
 		while (EOF != (ch = get_char(f)))
 			putc(ch, NewCrontab);
 
@@ -780,17 +783,19 @@ static void edit_cmd(void) {
   done:
 	log_it(RealUser, Pid, "END EDIT", User, 0);
 }
+
 /*
 * Check if crontab file can be installed or not 
 */
 static int test_cmd(void) {
-    if(check_syntax(NewCrontab) < 0) {
-    	fprintf(stderr, "Invalid Crontab file. Syntax issues were found.\n");
-        return (-2);
-    }else {
-    	fprintf(stderr, "No syntax issues were found in the crontab file\n");
-    }
-    return (0);
+	if (check_syntax(NewCrontab) < 0) {
+		fprintf(stderr, "Invalid crontab file. Syntax issues were found.\n");
+		return (-2);
+	}
+	else {
+		fprintf(stderr, "No syntax issues were found in the crontab file.\n");
+	}
+	return (0);
 }
 
 /* returns	0	on success
@@ -798,16 +803,12 @@ static int test_cmd(void) {
  *		-2	on install error
  */
 static int replace_cmd(void) {
-	char n[MAX_FNAME], envstr[MAX_ENVSTR];
+	char n[MAX_FNAME];
 	FILE *tmp;
-	int ch, eof, fd;
+	int ch, fd;
 	int error = 0;
-	entry *e;
 	uid_t file_owner;
-	char **envp;
 	char *safename;
-	int envs = 0, entries = 0;
-
 
 	safename = host_specific_filename("#tmp", "XXXXXXXXXX");
 	if (!safename || !glue_strings(TempFilename, sizeof TempFilename, SPOOL_DIR,
@@ -846,8 +847,8 @@ static int replace_cmd(void) {
 	/* copy the crontab to the tmp
 	 */
 	rewind(NewCrontab);
-	Set_LineNum(1)
-		while (EOF != (ch = get_char(NewCrontab)))
+	Set_LineNum(1);
+	while (EOF != (ch = get_char(NewCrontab)))
 		putc(ch, tmp);
 	if (ftruncate(fileno(tmp), ftell(tmp)) == -1) {
 		fprintf(stderr, "%s: error while writing new crontab to %s\n",
@@ -865,22 +866,23 @@ static int replace_cmd(void) {
 	}
 	rewind(tmp);
 
-    if((error = check_syntax(tmp)) < 0) {
-        fprintf(stderr, "Invalid Crontab file, can't install.\n");
-        goto done;
-    }
+	if ((error = check_syntax(tmp)) < 0) {
+		fprintf(stderr, "Invalid crontab file, can't install.\n");
+		goto done;
+	}
 
-	file_owner = (getgid() == geteuid() && getgid() == getegid()) ? ROOT_UID : pw->pw_uid;
+	file_owner = (getgid() == geteuid() &&
+		getgid() == getegid())? ROOT_UID : pw->pw_uid;
 
 #ifdef HAVE_FCHOWN
-	if (fchown(fileno(tmp), file_owner, (gid_t)-1) < OK) {
+	if (fchown(fileno(tmp), file_owner, (gid_t) - 1) < OK) {
 		perror("fchown");
 		fclose(tmp);
 		error = -2;
 		goto done;
 	}
 #else
-	if (chown(TempFilename, file_owner, (gid_t)-1) < OK) {
+	if (chown(TempFilename, file_owner, (gid_t) - 1) < OK) {
 		perror("chown");
 		fclose(tmp);
 		error = -2;
@@ -921,31 +923,37 @@ static int replace_cmd(void) {
 	}
 	return (error);
 }
+
 /*
  * Check the syntax of a crontab file
- *Returns:
- * 0 - no syntax issues
- * 1 - syntax issue (can be fixed by user)
- * 2 - any other error, which can not be fixed by user
+ * Returns:
+ *   0 no syntax issues
+ *  -1 syntax issue (can be fixed by user)
+ *  -2 any other error, which can not be fixed by user
  */
-static int check_syntax(FILE *crontab_file) {
-	Set_LineNum(1 - NHEADER_LINES)
-	
+static int check_syntax(FILE * crontab_file) {
 	char **envp = env_init();
+	int eof = FALSE;
+	int envs = 0, entries = 0;
+	CheckErrorCount = 0;
+
+	Set_LineNum(1 - NHEADER_LINES);
+
 	if (envp == NULL) {
 		fprintf(stderr, "%s: Cannot allocate memory.\n", ProgramName);
 		return (-2);
 	}
 
-    int eof = FALSE;
-    int error_count = 0, envs = 0, entries = 0;
-	while (!error_count && !eof) {
+	while (!CheckErrorCount && !eof) {
+		char envstr[MAX_ENVSTR];
+		entry *e;
+
 		if (!skip_comments(crontab_file)) {
-			check_error("too much non-parseable content(comments, empty lines, spaces, etc)");
+			check_error
+				("too much non-parseable content (comments, empty lines, spaces)");
 			break;
 		}
-		
-		char envstr[MAX_ENVSTR];
+
 		switch (load_env(envstr, crontab_file)) {
 		case ERR:
 			/* check for data before the EOF */
@@ -955,8 +963,8 @@ static int check_syntax(FILE *crontab_file) {
 			}
 			eof = TRUE;
 			break;
-		case FALSE: ;
-			entry *e = load_entry(crontab_file, check_error, pw, envp);
+		case FALSE:
+			e = load_entry(crontab_file, check_error, pw, envp);
 			if (e) {
 				++entries;
 				free_entry(e);
@@ -968,21 +976,25 @@ static int check_syntax(FILE *crontab_file) {
 		}
 	}
 	env_free(envp);
-	
+
 	if (envs > MAX_USER_ENVS) {
-		fprintf(stderr, "There are too many environment variables in the crontab file. Limit: %d\n", MAX_USER_ENVS);
+		fprintf(stderr,
+			"There are too many environment variables in the crontab file. Limit: %d\n",
+			MAX_USER_ENVS);
 		return (-1);
 	}
 
 	if (entries > MAX_USER_ENTRIES) {
-		fprintf(stderr, "There are too many entries in the crontab file. Limit: %d\n", MAX_USER_ENTRIES);
-        return (-1);
+		fprintf(stderr,
+			"There are too many entries in the crontab file. Limit: %d\n",
+			MAX_USER_ENTRIES);
+		return (-1);
 	}
 
 	if (CheckErrorCount != 0) {
 		return (-1);
 	}
-	
+
 	return 0;
 }
 
@@ -992,10 +1004,10 @@ static int hostset_cmd(void) {
 	int fd;
 	int error = 0;
 	char *safename;
-	
+
 	if (!HostSpecified)
 		gethostname(Host, sizeof Host);
-	
+
 	safename = host_specific_filename("#tmp", "XXXXXXXXXX");
 	if (!safename || !glue_strings(TempFilename, sizeof TempFilename, SPOOL_DIR,
 			safename, '/')) {
@@ -1017,7 +1029,7 @@ static int hostset_cmd(void) {
 	(void) signal(SIGINT, die);
 	(void) signal(SIGQUIT, die);
 
-	(void) fchmod(fd, 0600); /* not all mkstemp() implementations do this */
+	(void) fchmod(fd, 0600);	/* not all mkstemp() implementations do this */
 
 	if (fprintf(tmp, "%s\n", Host) < 0 || fclose(tmp) == EOF) {
 		fprintf(stderr, "%s: error while writing to %s\n",


### PR DESCRIPTION
Hi,

I made the changes to add the new option to test the crontab file syntax as proposed on #59.
Some considerations:

- I used '-T' as option cause anacron uses this same letter for the option that validates the anacrontab file. So I think it would be a good idea to keep the same;
- I moved the syntax check code to a function in order to reuse it on replace and test options;
- Some return messages were adjusted since now there are two options(replace and test) which uses the crontab file argument;

Please let me know if you have any questions or adjustments to be made.

Thanks!


Closes cronie-crond/cronie#59

Signed-off-by: Fernando Cappi <3818944+fcappi@users.noreply.github.com>