### PR TITLE
Fix crontab.5 man page, wrt verbiage regarding named lists/ranges for crontab entries

### DIFF
--- a/man/crontab.5
+++ b/man/crontab.5
@@ -212,7 +212,8 @@ two hours, you can use "*/2".
 .PP
 Names can also be used for the 'month' and 'day of week' fields.  Use the
 first three letters of the particular day or month (case does not
-matter).  Ranges or lists of names are not allowed.
+matter).  Ranges and lists of names are allowed. Examples: "mon,wed,fri",
+"jan-mar".
 .PP
 If the UID of the owner is 0 (root), the first character of a crontab
 entry can be "-" character. This will prevent cron from writing a syslog


### PR DESCRIPTION
The `crontab.5` manpage claims "Names can also be used for the 'month' and 'day of week' fields. ... Ranges or lists of names are not allowed." Based on my reading of the source code (not entirely to be trusted) and an experiment I ran (more trustworthy), this is not actually true.

See https://github.com/cronie-crond/cronie/issues/62 for more info.