### PR TITLE
Add missing Content-Transfer-Encoding.

### DIFF
--- a/anacron/runjob.c
+++ b/anacron/runjob.c
@@ -339,6 +339,7 @@ launch_job(job_rec *jr)
     xwrite(fd, "Content-Type: text/plain; charset=\"");
     xwrite(fd, nl_langinfo(CODESET));
     xwrite(fd, "\"\n");
+    xwrite(fd, "Content-Transfer-Encoding: 8bit\n");
     xwrite(fd, "Subject: Anacron job '");
     xwrite(fd, jr->ident);
     xwrite(fd, "' on ");

--- a/src/do_command.c
+++ b/src/do_command.c
@@ -497,7 +497,10 @@ static int child_process(entry * e, char **jobenv) {
 						*nl = ' ';
 					fprintf(mail, "Content-Type: %s\n", content_type);
 				}
-				if (content_transfer_encoding != NULL) {
+				if (content_transfer_encoding == NULL) {
+					fprintf(mail, "Content-Transfer-Encoding: 8bit\n");
+				}
+				else {
 					char *nl = content_transfer_encoding;
 					size_t ctlen = strlen(content_transfer_encoding);
 					while ((*nl != '\0')


### PR DESCRIPTION
When Crond and Anacron send email they specify a character encoding that they get from the locale, but they both omit the Content-Transfer-Encoding field. The default transfer encoding is 7bit, which means that the message body can only contain ASCII characters. If a job outputs any non-ASCII characters, then the email message becomes invalid and may be rejected by a standards-enforcing mail server. "8bit" should be specified to allow the message body to contain text in the encoding of the locale.