### PR TITLE
These cause compiler warnings on 32-bit systems

### DIFF
--- a/src/job.c
+++ b/src/job.c
@@ -72,8 +72,8 @@ void job_add(entry * e, user * u) {
 		e->envp = tenvp;
 	} else {
 		log_it(uname, getpid(), "ERROR", "getpwnam() failed - user unknown",errno);
-		Debug(DSCH | DEXT, ("%s:%d pid=%d time=%ld getpwnam(%s) failed errno=%d error=%s\n",
-			__FILE__,__LINE__,getpid(),time(NULL),uname,errno,strerror(errno)));
+		Debug(DSCH | DEXT, ("%s:%d pid=%d time=%lld getpwnam(%s) failed errno=%d error=%s\n",
+			__FILE__,__LINE__,getpid(),(long long)time(NULL),uname,errno,strerror(errno)));
 		return;
 	}
 

--- a/src/security.c
+++ b/src/security.c
@@ -121,7 +121,7 @@ int cron_set_job_security_context(entry *e, user *u ATTRIBUTE_UNUSED,
 		 * Ensure that these jobs never run in the same minute:
 		 */
 		minutely_time = time(NULL);
-		Debug(DSCH, ("Minute-ly job. Recording time %lu\n", minutely_time));
+		Debug(DSCH, ("Minute-ly job. Recording time %lld\n", (long long)minutely_time));
 	}
 
 #ifdef WITH_PAM


### PR DESCRIPTION
I submitted a package to the Alpine Linux project and their CI system was kind enough to report these build warnings on 32-bit architectures armv7 and x86.

```
src/job.c: In function 'job_add':
src/job.c:75:23: warning: format '%ld' expects argument of type 'long int', but argument 5 has type 'time_t' {aka 'long long int'} [-Wformat=]
   75 |   Debug(DSCH | DEXT, ("%s:%d pid=%d time=%ld getpwnam(%s) failed errno=%d error=%s\n",
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   76 |    __FILE__,__LINE__,getpid(),time(NULL),uname,errno,strerror(errno)));
      |                               ~~~~~~~~~~
      |                               |
      |                               time_t {aka long long int}

src/security.c: In function 'cron_set_job_security_context':
src/security.c:124:16: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'time_t' {aka 'long long int'} [-Wformat=]
  124 |   Debug(DSCH, ("Minute-ly job. Recording time %lu\n", minutely_time));
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~
      |                                                       |
      |                                                       time_t {aka long long int}
```