### PR TITLE
Fix race condition between file update and load_database

### DIFF
--- a/src/cron.c
+++ b/src/cron.c
@@ -312,11 +312,6 @@ int main(int argc, char *argv[]) {
 	log_it("CRON", pid, "INFO", buf, 0);
 
 	acquire_daemonlock(0);
-	database.head = NULL;
-	database.tail = NULL;
-	database.mtime = (time_t) 0;
-
-	load_database(&database);
 
 	fd = -1;
 #if defined WITH_INOTIFY
@@ -333,6 +328,12 @@ int main(int argc, char *argv[]) {
 		set_cron_watched(fd);
 	}
 #endif
+
+	database.head = NULL;
+	database.tail = NULL;
+	database.mtime = (time_t) 0;
+
+	load_database(&database);
 
 	set_time(TRUE);
 	run_reboot_jobs(&database);


### PR DESCRIPTION
Issue: https://github.com/cronie-crond/cronie/issues/73

This CR is to fix race condition between file update and load_database
when INOTIFY is enabled.

Previously, if crontab file is simultaneously written when crond starts up,
there is chances to miss the notification. This is because load_database
was performed before inotify watches get registered.

This CR will invoke `load_database` after watches are registered, so
crond doesn't miss such updates.


## Repro:

Repro was done with `./configure --prefix /usr --localstatedir=/var --with-inotify` on an AmazonLinux 2 (uname: `4.14.209-160.339.amzn2.x86_64`)

I added 1 min sleep after [load_database](https://github.com/cronie-crond/cronie/blob/22ae88868f48090e2a5ad4b9bb165581df91511f/src/cron.c#L319) with a log message.

Then, after starting crond, I updated crontab to have a simple job: `* * * * * date >> /tmp/date.out`

```

Dec 24 04:46:35 ip-172-31-32-72 crond[7869]: (CRON) STARTUP (1.5.5)
Dec 24 04:46:35 ip-172-31-32-72 crond[7869]: (CRON) INFO (RANDOM_DELAY will be scaled with factor 70% if used.)
Dec 24 04:46:35 ip-172-31-32-72 crond[7869]: (CRON) INFO (load_database)
Dec 24 04:46:35 ip-172-31-32-72 crond[7869]: (CRON) STAT FAILED (/usr/etc/cron.d): No such file or directory
Dec 24 04:46:35 ip-172-31-32-72 crond[7869]: (CRON) OPENDIR FAILED (/usr/etc/cron.d): No such file or directory
Dec 24 04:46:35 ip-172-31-32-72 crond[7869]: (CRON) INFO (sleeping for 1 min)
Dec 24 04:46:48 ip-172-31-32-72 crontab[7873]: (root) BEGIN EDIT (root)
Dec 24 04:46:50 ip-172-31-32-72 crontab[7873]: (root) REPLACE (root)
Dec 24 04:46:50 ip-172-31-32-72 crontab[7873]: (root) END EDIT (root)
Dec 24 04:47:35 ip-172-31-32-72 crond[7869]: (CRON) INFO (WITH_INOTIFY)
Dec 24 04:47:35 ip-172-31-32-72 crond[7869]: (CRON) INFO (Initializing inotify)
Dec 24 04:47:35 ip-172-31-32-72 crond[7869]: (CRON) INFO (running with inotify support)
Dec 24 04:47:35 ip-172-31-32-72 crond[7869]: (CRON) INFO (@reboot jobs will be run at computer's startup.)

```

The cronjob was never executed.


### without `--with-inotify` to validate repro steps

Also tested without `--with-inotify` and confirmed that there was cronjob logs

```
Dec 24 04:41:48 ip-172-31-32-72 crond[5924]: (CRON) STARTUP (1.5.5)
Dec 24 04:41:48 ip-172-31-32-72 crond[5924]: (CRON) INFO (RANDOM_DELAY will be scaled with factor 97% if used.)
Dec 24 04:41:48 ip-172-31-32-72 crond[5924]: (CRON) INFO (load_database)
Dec 24 04:41:48 ip-172-31-32-72 crond[5924]: (CRON) STAT FAILED (/usr/etc/cron.d): No such file or directory
Dec 24 04:41:48 ip-172-31-32-72 crond[5924]: (CRON) OPENDIR FAILED (/usr/etc/cron.d): No such file or directory
Dec 24 04:41:48 ip-172-31-32-72 crond[5924]: (CRON) INFO (sleeping for 1 min)
Dec 24 04:41:50 ip-172-31-32-72 crontab[5926]: (root) BEGIN EDIT (root)
Dec 24 04:41:53 ip-172-31-32-72 crontab[5926]: (root) REPLACE (root)
Dec 24 04:41:53 ip-172-31-32-72 crontab[5926]: (root) END EDIT (root)
Dec 24 04:42:48 ip-172-31-32-72 crond[5924]: (CRON) INFO (@reboot jobs will be run at computer's startup.)
Dec 24 04:43:01 ip-172-31-32-72 crond[5924]: (CRON) INFO (load_database)
Dec 24 04:43:01 ip-172-31-32-72 crond[5924]: (CRON) STAT FAILED (/usr/etc/cron.d): No such file or directory
Dec 24 04:43:01 ip-172-31-32-72 crond[5924]: (CRON) OPENDIR FAILED (/usr/etc/cron.d): No such file or directory
Dec 24 04:43:01 ip-172-31-32-72 crond[5924]: (root) RELOAD (/var/spool/cron/root)
Dec 24 04:43:01 ip-172-31-32-72 CROND[5942]: (root) CMD (date >> /tmp/date.out)
Dec 24 04:43:01 ip-172-31-32-72 CROND[5941]: (root) CMDEND (date >> /tmp/date.out)
```

