### PR TITLE
Ignore batteries in /sys/class/power_supply, add mechanism for running anacron on battery

### DIFF
--- a/anacron.sysconfig
+++ b/anacron.sysconfig
@@ -1,0 +1,11 @@
+# Settings for anacron
+
+# ENABLE_ON_BATTERY defines the behavior of anacron when the system is
+# on battery power.  If no power supply is online, the anacron by
+# default will not run.
+# 
+# ENABLE_ON_BATTERY=no  - default, do not run anacron jobs if no power
+#                         supply is online
+# ENABLE_ON_BATTERY=yes - run anacron jobs even if all power supplies
+#                         are offline
+ENABLE_ON_BATERY=no

--- a/contrib/0anacron
+++ b/contrib/0anacron
@@ -1,4 +1,5 @@
 #!/bin/sh
+source /etc/sysconfig/anacron
 # Check whether 0anacron was run today already
 if test -r /var/spool/anacron/cron.daily; then
     day=`cat /var/spool/anacron/cron.daily`
@@ -7,19 +8,24 @@ if [ `date +%Y%m%d` = "$day" ]; then
     exit 0
 fi
 
-# Do not run jobs when on battery power
-online=1
-for psupply in /sys/class/power_supply/* ; do
-    if [ -f "$psupply/online" ]; then
-        if [ `cat "$psupply/online" 2>/dev/null`x = 1x ]; then
-            online=1
-            break
-        else
-            online=0
+# Do not run jobs when on battery power unless specified
+if [ "${ENABLE_ON_BATTERY}" != "yes" ] ; then
+    online=1
+    for psupply in /sys/class/power_supply/* ; do
+        psupply_type=`cat "$psupply/type" 2>/dev/null`x
+        if [ "$psupply_type" != "Batteryx" ] ; then
+            if [ -f "$psupply/online" ]; then
+                if [ `cat "$psupply/online" 2>/dev/null`x = 1x ]; then
+                    online=1
+                    break
+                else
+                    online=0
+                fi
+            fi
         fi
+    done
+    if [ $online = 0 ]; then
+        exit 0
     fi
-done
-if [ $online = 0 ]; then
-    exit 0
 fi
 /usr/sbin/anacron -s

--- a/cronie.spec
+++ b/cronie.spec
@@ -111,6 +111,7 @@ mkdir -pm755 $RPM_BUILD_ROOT%{_sysconfdir}/cron.d/
     rm -f $RPM_BUILD_ROOT%{_sysconfdir}/pam.d/crond
 %endif
 install -m 644 crond.sysconfig $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/crond
+install -m 644 anacron.sysconfig $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/anacron
 touch $RPM_BUILD_ROOT%{_sysconfdir}/cron.deny
 install -m 644 contrib/anacrontab $RPM_BUILD_ROOT%{_sysconfdir}/anacrontab
 install -c -m755 contrib/0hourly $RPM_BUILD_ROOT%{_sysconfdir}/cron.d/0hourly
@@ -190,6 +191,7 @@ exit 0
 %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/pam.d/crond
 %endif
 %config(noreplace) %{_sysconfdir}/sysconfig/crond
+%config(noreplace) %{_sysconfdir}/sysconfig/anacron
 %config(noreplace) %{_sysconfdir}/cron.deny
 %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/cron.d/0hourly
 %attr(0644,root,root) /lib/systemd/system/crond.service


### PR DESCRIPTION
Fix #83 by not including batteries when looking for online power supplies.  Also add ability to run anacron jobs even when running on battery through a value in the newly-introduced `/etc/sysconfig/anacron` file.
I verified the change on the system on which I originally produced #83, and confirmed that the RPM build includes the `/etc/sysconfig/anacron` that is introduced with this change.