### PR TITLE
Address issues found by coverity scan

### DIFF
--- a/anacron/main.c
+++ b/anacron/main.c
@@ -44,8 +44,8 @@ int day_now;
 int year, month, day_of_month;                 /* date anacron started */
 
 char *program_name;
-char *anacrontab;
-char *spooldir;
+char *anacrontab = NULL;
+char *spooldir = NULL;
 int serialize, force, update_only, now,
     no_daemon, quiet, testing_only;            /* command-line options */
 char **job_args;                       	       /* vector of "job" command-line arguments */
@@ -128,12 +128,14 @@ parse_opts(int argc, char *argv[])
 	    quiet = 1;
 	    break;
 	case 't':
+	    free(anacrontab);
 	    anacrontab = strdup(optarg);
 	    break;
 	case 'T':
 	    testing_only = 1;
 	    break;
 	case 'S':
+	    free(spooldir);
 	    spooldir = strdup(optarg);
 	    break;
 	case 'V':
@@ -208,9 +210,11 @@ go_background(void)
     /* stdin is already closed */
 
     if (fclose(stdout)) die_e("Can't close stdout");
+    /* coverity[leaked_handle] – fd 1 closed automatically */
     xopen(1, "/dev/null", O_WRONLY);
 
     if (fclose(stderr)) die_e("Can't close stderr");
+    /* coverity[leaked_handle] – fd 2 closed automatically */
     xopen(2, "/dev/null", O_WRONLY);
 
     pid = xfork();

--- a/anacron/runjob.c
+++ b/anacron/runjob.c
@@ -237,7 +237,9 @@ launch_mailer(job_rec *jr)
 	xcloselog();
 
 	/* Ensure stdout/stderr are sane before exec-ing sendmail */
+	/* coverity[leaked_handle] – STDOUT closed automatically */
 	xclose(STDOUT_FILENO); xopen(STDOUT_FILENO, "/dev/null", O_WRONLY);
+	/* coverity[leaked_handle] – STDERR closed automatically */
 	xclose(STDERR_FILENO); xopen(STDERR_FILENO, "/dev/null", O_WRONLY);
 	xclose(jr->output_fd);
 

--- a/src/crontab.c
+++ b/src/crontab.c
@@ -872,6 +872,7 @@ static int replace_cmd(void) {
 
 	if ((error = check_syntax(tmp)) < 0) {
 		fprintf(stderr, "Invalid crontab file, can't install.\n");
+		fclose(tmp);
 		goto done;
 	}
 

--- a/src/database.c
+++ b/src/database.c
@@ -559,7 +559,8 @@ int load_database(cron_db * old_db) {
 			if (not_a_crontab(dp))
 				continue;
 
-			strncpy(fname, dp->d_name, NAME_MAX); fname[NAME_MAX] = '\0';
+			strncpy(fname, dp->d_name, NAME_MAX);
+			fname[NAME_MAX] = '\0';
 
 			if (!glue_strings(tabname, sizeof tabname, SPOOL_DIR, fname, '/'))
 				continue;	/* XXX log? */

--- a/src/database.c
+++ b/src/database.c
@@ -559,7 +559,7 @@ int load_database(cron_db * old_db) {
 			if (not_a_crontab(dp))
 				continue;
 
-			strncpy(fname, dp->d_name, NAME_MAX + 1);
+			strncpy(fname, dp->d_name, NAME_MAX); fname[NAME_MAX] = '\0';
 
 			if (!glue_strings(tabname, sizeof tabname, SPOOL_DIR, fname, '/'))
 				continue;	/* XXX log? */

--- a/src/pw_dup.c
+++ b/src/pw_dup.c
@@ -121,6 +121,7 @@ pw_dup(const struct passwd *pw) {
 		cp += ssize;
 	}
 
+	/* cppcheck-suppress[memleak symbolName=cp] memory originally pointed to by cp returned via newpw */
 	return (newpw);
 }
 


### PR DESCRIPTION
These issues were found by running several static checkers on the codebase (see [cronie-1.5.7-coverity-imp.err.txt](https://github.com/cronie-crond/cronie/files/6399748/cronie-1.5.7-coverity-imp.err.txt) for the original report).