### PR TITLE
Increase the maximum number of crontab entries

### DIFF
--- a/src/macros.h
+++ b/src/macros.h
@@ -59,7 +59,7 @@
 #define	ROOT_UID	0	/* don't change this, it really must be root */
 #define	ROOT_USER	"root"	/* ditto */
 #define MAX_USER_ENVS	1000	/* maximum environment variables in user's crontab */
-#define MAX_USER_ENTRIES 1000	/* maximum crontab entries in user's crontab */
+#define MAX_USER_ENTRIES 10000	/* maximum crontab entries in user's crontab */
 #define MAX_GARBAGE	32768	/* max num of chars of comments and whitespaces between entries */
 #define MAX_CLOSE_FD	10000	/* max fd num to close when spawning a child process */
 


### PR DESCRIPTION
Old limit is considered too low for users with edge cases.

Fixes #91.