### PR TITLE
use the configure runstatedir directory for pid file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -266,6 +266,8 @@ AS_IF([test "$enable_anacron" != no && test "$have_obstack" = no], [
 	CPPFLAGS="$CPPFLAGS -I\$(top_srcdir)/obstack"
 ])
 
+AM_CONDITIONAL(HAS_RUNSTATE, [test x$runstatedir != x])
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
 

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -61,6 +61,13 @@ src_crontab_LDADD = $(LIBSELINUX) $(LIBPAM) $(LIBAUDIT)
 # Depends on this Makefile, because it uses make variables.
 # CCD 2010/09/10 added CRON_HOSTNAME for clustered-cron.
 CLEANFILES += cron-paths.h
+if HAS_RUNSTATE
+cronpidcomment=/* directory of cron pid file */
+cronpiddir=\#define CRON_PID_DIR "$(runstatedir)"
+else
+cronpidcomment=
+cronpiddir=
+endif
 cron-paths.h: Makefile
 	@echo 'creating $@'
 	@sed >$@ 's/ *\\$$//' <<\END #\
@@ -96,8 +103,8 @@ cron-paths.h: Makefile
 	#define	CRON_ALLOW	"$(sysconfdir)/cron.allow" \
 	#define	CRON_DENY	"$(sysconfdir)/cron.deny" \
 	\
-			/* directory of cron pid file */ \
-	#define CRON_PID_DIR    "$(runstatedir)" \
+			$(cronpidcomment) \
+	$(cronpiddir) \
 	\
 			/* 4.3BSD-style crontab f.e. /etc/crontab */ \
 	#define SYSCRONTAB	"$(SYSCRONTAB)" \

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -96,6 +96,9 @@ cron-paths.h: Makefile
 	#define	CRON_ALLOW	"$(sysconfdir)/cron.allow" \
 	#define	CRON_DENY	"$(sysconfdir)/cron.deny" \
 	\
+			/* directory of cron pid file */ \
+	#define CRON_PID_DIR    "$(runstatedir)" \
+	\
 			/* 4.3BSD-style crontab f.e. /etc/crontab */ \
 	#define SYSCRONTAB	"$(SYSCRONTAB)" \
 	\

--- a/src/pathnames.h
+++ b/src/pathnames.h
@@ -36,10 +36,14 @@
 			 * PIDDIR must end in '/'.
 			 * (Don't ask why the default is "/etc/".)
 			 */
-#ifdef _PATH_VARRUN
-# define PIDDIR	_PATH_VARRUN
+#ifdef CRON_PID_DIR
+# define PIDDIR CRON_PID_DIR "/"
 #else
-# define PIDDIR SYSCONFDIR "/"
+# ifdef _PATH_VARRUN
+#  define PIDDIR	_PATH_VARRUN
+# else
+#  define PIDDIR SYSCONFDIR "/"
+# endif
 #endif
 #define PIDFILE		"crond.pid"
 #define _PATH_CRON_PID	PIDDIR PIDFILE


### PR DESCRIPTION
For example:

```
./configure --runstatedir=somedirectory
make
```

Now crond uses ``somedirectory`` for storing and checking crond.pid