### PR TITLE
Fix RandomScale calculation

### DIFF
--- a/src/cron.c
+++ b/src/cron.c
@@ -308,7 +308,7 @@ int main(int argc, char *argv[]) {
 	if (gettimeofday(&tv, &tz) != 0)
 		tv.tv_usec = 0;
 	srandom((unsigned int)(pid + tv.tv_usec));
-	RandomScale = (double)random() / (double)RAND_MAX;
+	RandomScale = (double)random() / (double)(1lu << 31);
 	snprintf(buf, sizeof(buf), "RANDOM_DELAY will be scaled with factor %d%% if used.", (int)(RandomScale*100));
 	log_it("CRON", pid, "INFO", buf, 0);
 


### PR DESCRIPTION
`random()` returns a value in `[0 .. 2^31[` (cf. [posix spec](https://pubs.opengroup.org/onlinepubs/9699919799/functions/random.html)).
On some systems, `RAND_MAX != 2^31 - 1`.
This patch ensures that scaling factor is in < 100%

see Issue #98 

We divide by 2^31, not 2^31-1, because semantically the `RANDOM_DELAY` probably defines an open interval, hence scale should be in `[0..100[` and not equal to 100%