### PR TITLE
Allow user to run anacron jobs on battery

### DIFF
--- a/contrib/0anacron
+++ b/contrib/0anacron
@@ -10,7 +10,7 @@ fi
 # Check whether run on battery should be allowed
 . /etc/default/anacron
 
-if [ $ANACRON_RUN_ON_BATTERY_POWER != "yes" ]; then
+if [ "$ANACRON_RUN_ON_BATTERY_POWER" != "yes" ]; then
 
     # Do not run jobs when on battery power
     online=1

--- a/contrib/0anacron
+++ b/contrib/0anacron
@@ -8,15 +8,9 @@ if [ `date +%Y%m%d` = "$day" ]; then
 fi
 
 # Check whether run on battery should be allowed
-check_online=1
-if test -r /etc/default/anacron; then
-    run_on_battery=`grep ANACRON_RUN_ON_BATTERY_POWER /etc/default/anacron | awk -F'=' '{print $2}'`
-    if [ $run_on_battery = "yes" ]; then
-    check_online=0
-    fi
-fi
+. /etc/default/anacron
 
-if [ $check_online = 1 ]; then
+if [ $ANACRON_RUN_ON_BATTERY_POWER != "yes" ]; then
 
     # Do not run jobs when on battery power
     online=1

--- a/contrib/0anacron
+++ b/contrib/0anacron
@@ -7,19 +7,32 @@ if [ `date +%Y%m%d` = "$day" ]; then
     exit 0
 fi
 
-# Do not run jobs when on battery power
-online=1
-for psupply in /sys/class/power_supply/* ; do
-    if [ `cat "$psupply/type" 2>/dev/null`x = Mainsx ] && [ -f "$psupply/online" ]; then
-        if [ `cat "$psupply/online" 2>/dev/null`x = 1x ]; then
-            online=1
-            break
-        else
-            online=0
-        fi
+# Check whether run on battery should be allowed
+check_online=1
+if test -r /etc/default/anacron; then
+    run_on_battery=`grep ANACRON_RUN_ON_BATTERY_POWER /etc/default/anacron | awk -F'=' '{print $2}'`
+    if [ $run_on_battery = "yes" ]; then
+    check_online=0
     fi
-done
-if [ $online = 0 ]; then
-    exit 0
+fi
+
+if [ $check_online = 1 ]; then
+
+    # Do not run jobs when on battery power
+    online=1
+    for psupply in /sys/class/power_supply/* ; do
+        if [ `cat "$psupply/type" 2>/dev/null`x = Mainsx ] && [ -f "$psupply/online" ]; then
+            if [ `cat "$psupply/online" 2>/dev/null`x = 1x ]; then
+                online=1
+                break
+            else
+                online=0
+            fi
+        fi
+    done
+    if [ $online = 0 ]; then
+        exit 0
+    fi
+
 fi
 /usr/sbin/anacron -s


### PR DESCRIPTION
The user can allow running anacron jobs on battery by adding the string `ANACRON_RUN_ON_BATTERY_POWER=yes` to the file `/etc/default/anacron`.