### PR TITLE
Using _PATH_STDPATH instead of _PATH_DEFPATH

### DIFF
--- a/src/cron.c
+++ b/src/cron.c
@@ -185,7 +185,7 @@ static void usage(void) {
 	fprintf(stderr, " -f         run in foreground, the same as -n\n");
 	fprintf(stderr, " -p         permit any crontab\n");
 	fprintf(stderr, " -P         inherit PATH from environment instead of using default value");
-	fprintf(stderr, "            of \"%s\"\n", _PATH_DEFPATH);
+	fprintf(stderr, "            of \"%s\"\n", _PATH_STDPATH);
 	fprintf(stderr, " -c         enable clustering support\n");
 	fprintf(stderr, " -s         log into syslog instead of sending mails\n");
 	fprintf(stderr, " -V         print version and exit\n");
@@ -249,7 +249,7 @@ int main(int argc, char *argv[]) {
 	check_spool_dir();
 
 	if (ChangePath) {
-		if (setenv("PATH", _PATH_DEFPATH, 1) < 0) {
+		if (setenv("PATH", _PATH_STDPATH, 1) < 0) {
 			log_it("CRON", pid, "DEATH", "can't setenv PATH",
 				errno);
 			exit(1);

--- a/src/entry.c
+++ b/src/entry.c
@@ -376,11 +376,11 @@ entry *load_entry(FILE * file, void (*error_func) (), struct passwd *pw,
 		char *defpath;
 
 		if (ChangePath)
-			defpath = _PATH_DEFPATH;
+			defpath = _PATH_STDPATH;
 		else {
 			defpath = getenv("PATH");
 			if (defpath == NULL)
-				defpath = _PATH_DEFPATH;
+				defpath = _PATH_STDPATH;
 		}
 
 		if (glue_strings(envstr, sizeof envstr, "PATH", defpath, '=')) {

--- a/src/pathnames.h
+++ b/src/pathnames.h
@@ -53,8 +53,8 @@
 # define _PATH_BSHELL "/bin/sh"
 #endif
 
-#ifndef _PATH_DEFPATH
-# define _PATH_DEFPATH "/usr/bin:/bin"
+#ifndef _PATH_STDPATH
+# define _PATH_STDPATH "/usr/bin:/bin:/usr/sbin:/sbin"
 #endif
 
 #ifndef _PATH_TMP


### PR DESCRIPTION
If not using paths.h provided by the system we'll set _PATH_STDPATH to
"/usr/bin:/bin:/usr/sbin:/sbin".