### PR TITLE
Set empty return path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -196,14 +196,14 @@ AC_DEFINE(DEBUGGING,1,[Code will be built with debug info.])
 
 AC_DEFINE(MAILARG,"/usr/sbin/sendmail",[There will be path to sendmail.])
 
-AC_DEFINE(MAILFMT,"%s -FCronDaemon -i -odi -oem -oi -t -f '<>'",
+AC_DEFINE(MAILFMT,"%s -FCronDaemon -i -odi -oem -oi -t -f <>",
 [-i    = don't terminate on "." by itself
 -Fx   = Set full-name of sender
 -odi  = Option Deliverymode Interactive
 -oem  = Option Errors Mailedtosender
 -oi   = Ignore "." alone on a line
 -t    = Get recipient from headers
--f '<>' = Empty envelope sender address
+-f <> = Empty envelope sender address
 -d = undocumented but common flag.])
 
 AC_DEFINE(SYSLOG,1,[Using syslog for log messages.])

--- a/configure.ac
+++ b/configure.ac
@@ -196,14 +196,14 @@ AC_DEFINE(DEBUGGING,1,[Code will be built with debug info.])
 
 AC_DEFINE(MAILARG,"/usr/sbin/sendmail",[There will be path to sendmail.])
 
-AC_DEFINE(MAILFMT,"%s -FCronDaemon -i -odi -oem -oi -t -f %s",
+AC_DEFINE(MAILFMT,"%s -FCronDaemon -i -odi -oem -oi -t -f '<>'",
 [-i    = don't terminate on "." by itself
 -Fx   = Set full-name of sender
 -odi  = Option Deliverymode Interactive
 -oem  = Option Errors Mailedtosender
 -oi   = Ignore "." alone on a line
 -t    = Get recipient from headers
--f %s = Envelope sender address
+-f '<>' = Empty envelope sender address
 -d = undocumented but common flag.])
 
 AC_DEFINE(SYSLOG,1,[Using syslog for log messages.])

--- a/src/do_command.c
+++ b/src/do_command.c
@@ -453,7 +453,7 @@ static int child_process(entry * e, char **jobenv) {
 				if (MailCmd[0] == '\0') {
 					int len;
 
-					len = snprintf(mailcmd, sizeof mailcmd, MAILFMT, MAILARG, mailfrom);
+					len = snprintf(mailcmd, sizeof mailcmd, MAILFMT, MAILARG);
 					if (len < 0) {
 						fprintf(stderr, "mailcmd snprintf failed\n");
 						(void) _exit(ERROR_EXIT);


### PR DESCRIPTION
Hi,

our mail server admins keep complaining about vacation messages (e.g. from Microsoft Exchange) which cannot be delivered locally.

After investigating further we found out that these messages got sent as a reply to cron mails. The sender is often "root@some-hostname" which is not a working email address.

The solution to this problem is quite simple: Avoid the sending of automatic replies. I saw that cronie tries to accomplish this by adding the header "Precedence: bulk". But RFC 3834 states:

```
Because Precedence is not a standard header field, and its use and interpretation
vary widely in the wild, no particular responder behavior in the presence of
Precedence is recommended by this specification.
```

Thankfuly the RFC also gives the correct way to do this:

```
Responders MUST NOT generate any response for which the destination
of that response would be a null address (e.g., an address for which
SMTP MAIL FROM or Return-Path is <>)
```

So this patch just hardcodes the return-path to <> (by using the -f option to sendmail). This prevents Exchange from sending vacation mails to cron mails.

Thanks for reviewing,

Christopher
