### PR TITLE
man: Fix some spelling typos

### DIFF
--- a/man/anacron.8
+++ b/man/anacron.8
@@ -184,7 +184,7 @@ Anacron never removes timestamp files.  Remove unused files manually.
 Anacron uses up to two file descriptors for each active job.  It may run
 out of descriptors if there are lots of active jobs.  See
 .B echo $(($(ulimit -n) / 2))
-for information how many concurent jobs anacron may run.
+for information how many concurrent jobs anacron may run.
 .PP
 Mail comments, suggestions and bug reports to
 .MT shaleh@\:(debian.\:org|\:valinux.\:com)

--- a/man/cronnext.1
+++ b/man/cronnext.1
@@ -35,7 +35,7 @@ Do not consider the crontabs of the specified users.
 Do not consider the system crontab, usually the
 .I /etc/crontab
 file.  The system crontab usually contains the hourly, daily, weekly and
-montly crontabs, which might be better dealt with
+monthly crontabs, which might be better dealt with
 .BR anacron (8).
 .TP
 .BI \-a


### PR DESCRIPTION
This patch fixes some spelling typo in anacron.8 and cronnext.1

Signed-off-by: Masanari Iida <standby24x7@gmail.com>