### PR TITLE
Make a backup of the crontab file on edition and deletion

### DIFF
--- a/man/crontab.1
+++ b/man/crontab.1
@@ -119,6 +119,19 @@ an environment variable
 .I NO_COLOR
 is set.
 .PP
+On edition or deletion of the crontab, a backup of the last crontab will be saved to
+.I $XDG_CACHE_HOME/crontab/crontab.bak
+or 
+.I $XDG_CACHE_HOME/crontab/crontab.<user>.bak
+if
+.B -u
+is used.
+If the
+.I XDG_CACHE_HOME
+environment variable is not set,
+.I $HOME/.cache
+will be used instead.
+.PP
 .SH "OPTIONS"
 .TP
 .B "\-u"


### PR DESCRIPTION
This will help users that mistakenly run `crontab -r`, by providing a way to restore the crontab file

A bit related to #12