### PR TITLE
anacron: read SENDMAIL variable from anacrontab

### DIFF
--- a/anacron/global.h
+++ b/anacron/global.h
@@ -30,6 +30,7 @@
 #define SYSLOG_FACILITY LOG_CRON
 #define EXPLAIN_LEVEL LOG_NOTICE  /* informational messages */
 #define COMPLAIN_LEVEL LOG_ERR    /* error messages */
+#define DEBUG DEBUG
 #define DEBUG_LEVEL LOG_DEBUG     /* only used when DEBUG is defined */
 
 /* Mail interface.  (All MTAs should supply this command) */

--- a/anacron/runjob.c
+++ b/anacron/runjob.c
@@ -207,6 +207,7 @@ xwait(pid_t pid , int *status)
 static void
 launch_mailer(job_rec *jr)
 {
+    char *mailer;
     pid_t pid;
     struct stat buf;
 
@@ -247,13 +248,22 @@ launch_mailer(job_rec *jr)
 	/* fdflags = fcntl(0, F_GETFL); fdflags &= ~O_APPEND; */
 	/* fcntl(0, F_SETFL, fdflags ); */
 
-	/* Here, I basically mirrored the way /usr/sbin/sendmail is called
-	 * by cron on a Debian system, except for the "-oem" and "-or0s"
-	 * options, which don't seem to be appropriate here.
-	 * Hopefully, this will keep all the MTAs happy. */
-	execl(SENDMAIL, SENDMAIL, "-FAnacron", "-odi",
-	      jr->mailto, (char *)NULL);
-	die_e("Can't exec " SENDMAIL);
+        /* Get SENDMAIL variable from the environment if set. 
+        /* If not, will use the predefined SENDMAIL from global.h */
+        mailer = getenv("SENDMAIL");
+        
+        if (mailer == NULL) {
+            /* Here, I basically mirrored the way /usr/sbin/sendmail is called
+            * by cron on a Debian system, except for the "-oem" and "-or0s"
+            * options, which don't seem to be appropriate here.
+            * Hopefully, this will keep all the MTAs happy. */
+            execl(SENDMAIL, SENDMAIL, "-FAnacron", "-odi",
+                jr->mailto, (char *)NULL);
+            die_e("Can't exec " SENDMAIL); 
+        } else {
+            execl(mailer, mailer, (char *)NULL);
+            die_e("Can't exec the mailer");
+        }
     }
     /* parent */
     /* record mailer pid */


### PR DESCRIPTION
Use alternative mailer command.

As briefly discussed in https://github.com/cronie-crond/cronie/issues/133 the change looks for SENDMAIL environmant variable, and if it is set, uses it as an alternative mailer. It strips the command line arguments from the execl() call, and lets the mailer sort out the standard input. Perhaps it's not ideal, but I'd like to hear some comments. 

For my personal use-case, `logger` very easily takes the standard input and sends it into syslog, eliminating any need for local mail setup. Which was my goal to begin with. :-) Full disclosure. 

Another possible issue is that you can't specify command line parameters for the alternative mailer, it has to be just a path to the binary. 