### PR TITLE
change the signal when reload from a hub to a urg

### DIFF
--- a/contrib/cronie.systemd
+++ b/contrib/cronie.systemd
@@ -5,7 +5,7 @@ After=auditd.service nss-user-lookup.target systemd-user-sessions.service time-s
 [Service]
 EnvironmentFile=/etc/sysconfig/crond
 ExecStart=/usr/sbin/crond -n $CRONDARGS
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=/bin/kill -URG $MAINPID
 KillMode=process
 Restart=on-failure
 RestartSec=30s


### PR DESCRIPTION
Avoid the occasional occurrence of `Active: deactivation` in the crond service when both `systemctl restart crond` and `systemctl reload crond` are executed simultaneously

Fix [issue 139](https://github.com/cronie-crond/cronie/issues/139)