### PR TITLE
Add support for simple log outputs as alternative to email

### DIFF
--- a/anacron/global.h
+++ b/anacron/global.h
@@ -62,6 +62,7 @@ struct job_rec1 {
    char *ident;
    char *command;
    char *mailto;
+   int inherit_outputs;
 
    int tab_line;
    int arg_num;

--- a/anacron/global.h
+++ b/anacron/global.h
@@ -62,7 +62,7 @@ struct job_rec1 {
    char *ident;
    char *command;
    char *mailto;
-   int inherit_outputs;
+   int no_mail_output;
 
    int tab_line;
    int arg_num;

--- a/anacron/runjob.c
+++ b/anacron/runjob.c
@@ -303,7 +303,7 @@ launch_job(job_rec *jr)
 
     setup_env(jr);
 
-    jr->inherit_outputs = getenv("INHERIT_OUTPUTS") != NULL;
+    jr->inherit_outputs = getenv("INHERIT_OUTPUTS") != NULL && *getenv("INHERIT_OUTPUTS");
 
     /* Set up email functionality if outputs should *not* be inherited  */
     if (!jr->inherit_outputs) {

--- a/anacron/runjob.c
+++ b/anacron/runjob.c
@@ -172,7 +172,7 @@ run_job(const job_rec *jr)
         xclose(1);
         xclose(2);
         if (dup2(jr->output_fd, 1) != 1 || dup2(jr->output_fd, 2) != 2)
-        die_e("dup2() error");     /* dup2 also clears close-on-exec flag */
+            die_e("dup2() error");     /* dup2 also clears close-on-exec flag */
         in_background = 0;  /* now, errors will be mailed to the user */
     }
 
@@ -295,6 +295,7 @@ launch_job(job_rec *jr)
     char *mailfrom;
     char mailto_expanded[MAX_EMAILSTR];
     char mailfrom_expanded[MAX_EMAILSTR];
+    char *no_mail_output;
 
     /* get hostname */
     if (gethostname(hostname, 512)) {
@@ -303,7 +304,8 @@ launch_job(job_rec *jr)
 
     setup_env(jr);
 
-    jr->no_mail_output = getenv("NO_MAIL_OUTPUT") != NULL && *getenv("NO_MAIL_OUTPUT");
+    no_mail_output = getenv("NO_MAIL_OUTPUT");
+    jr->no_mail_output = no_mail_output != NULL && *no_mail_output;
 
     /* Set up email functionality if it isn't disabled  */
     if (!jr->no_mail_output) {
@@ -388,8 +390,8 @@ tend_job(job_rec *jr, int status)
 
     update_timestamp(jr);
     unlock(jr);
-    if (!jr->no_mail_output && file_size(jr->output_fd) > jr->mail_header_size) mail_output = 1;
-    else mail_output = 0;
+
+    mail_output = !jr->no_mail_output && file_size(jr->output_fd) > jr->mail_header_size;
 
     m = mail_output ? " (produced output)" : "";
     if (WIFEXITED(status) && WEXITSTATUS(status) == 0)

--- a/anacron/runjob.c
+++ b/anacron/runjob.c
@@ -303,6 +303,7 @@ launch_job(job_rec *jr)
 
     setup_env(jr);
 
+    /* Outputs are inherited if INHERIT_OUTPUTS is defined and non-empty  */
     jr->inherit_outputs = getenv("INHERIT_OUTPUTS") != NULL && *getenv("INHERIT_OUTPUTS");
 
     /* Set up email functionality if outputs should *not* be inherited  */

--- a/man/anacrontab.5
+++ b/man/anacrontab.5
@@ -82,7 +82,7 @@ and
 variables are expanded, so setting them as in the following example works as expected: MAILFROM=cron-$USER@cron.com ($USER is replaced by the system user) ) 
 .PP
 If
-.I INHERIT_OUTPUTS
+.I NO_MAIL_OUTPUT
 is defined (and non-empty), anacron's output includes the outputs of job processes and the mail functionality is disabled.
 .PP
 .PP

--- a/man/anacrontab.5
+++ b/man/anacrontab.5
@@ -81,6 +81,10 @@ and
 .I MAILTO 
 variables are expanded, so setting them as in the following example works as expected: MAILFROM=cron-$USER@cron.com ($USER is replaced by the system user) ) 
 .PP
+If
+.I INHERIT_OUTPUTS
+is defined (and non-empty), anacron's output includes the outputs of job processes and the mail functionality is disabled.
+.PP
 .PP
 Empty lines are either blank lines, line containing white spaces only, or
 lines with white spaces followed by a '#' followed by an arbitrary

--- a/man/anacrontab.5
+++ b/man/anacrontab.5
@@ -83,7 +83,7 @@ variables are expanded, so setting them as in the following example works as exp
 .PP
 If
 .I NO_MAIL_OUTPUT
-is defined (and non-empty), anacron's output includes the outputs of job processes and the mail functionality is disabled.
+is defined (and non-empty), the standard output and error descriptors of job processes are not redirected and e-mailed.
 .PP
 .PP
 Empty lines are either blank lines, line containing white spaces only, or


### PR DESCRIPTION
This PR adds support for a new environment variable `INHERIT_OUTPUTS` which, when set, indicates that the outputs (stdout and stderr) of a job should not be sent by mail and instead just be written to stdout/stderr as usual. The value of this feature is that it allows for a more uniform logging approach without a mail server set up. 

For example, on my system, `anacron` is run by `cronie` every hour (as is the default). The outputs of cronie and  anacron are logged in `journalctl`. It would be nice to have the logs of my anacron jobs there as well, which can be achieved by leaving stdout and stderr of the job processes as-is.

This PR's motivation is similar to that of #135 but completely ignores the mail functionality.