### PR TITLE
Explain how to do skip values for non-multiples of the time unit

### DIFF
--- a/man/crontab.5
+++ b/man/crontab.5
@@ -225,7 +225,8 @@ execution for every other hour (the alternative in the V7 standard is
 also permitted after an asterisk, so if specifying a job to be run every
 two hours, you can use "*/2". Please note that steps are evaluated just
 within the field they are applied to. For example "*/23" in hours field
-means to execute the job on the hour 0 and the hour 23 within a calendar day.
+means to execute the job on the hour 0 and the hour 23 within a calendar
+day. See "NOTES" below for a workaround.
 .PP
 Names can also be used for the 'month' and 'day of week' fields.  Use the
 first three letters of the particular day or month (case does not
@@ -289,6 +290,20 @@ optional.
 MAILTO=root
 * * * * * root touch /tmp/file
 .fi
+.SH NOTES
+As noted above, skip values only operate within the time period they\'re
+attached to. For example, specifying "0/35" for the minute field of a
+crontab entry won\'t cause that entry to be executed every 35 minutes;
+instead, it will be executed twice every hour, at 0 and 35 minutes past.
+For more fine-grained control you can do something like this:
+.nf
+* * * * * if [ $(expr \( $(date +\%s) / 60 \) \% 58) = 0 ]; then echo this runs every 58 minutes; fi
+0 * * * * if [ $(expr \( $(date +\%s) / 3600 \) \% 23) = 0 ]; then echo this runs every 23 hours on the hour; fi
+.fi
+Adjust as needed if your
+.BR date (1)
+command does not accept "+%s" as the format string specifier to output
+the current UNIX timestamp.
 .SH SELinux with multi level security (MLS)
 In a crontab, it is important to specify a security level by
 .I crontab \-s


### PR DESCRIPTION
Add a NOTES section explaining how you can run a job, e.g., every 58 minutes or every 23 hours, since the /# skip syntax doesn't support that.

As per #142.