### PR TITLE
Step size out of bound handling

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -677,6 +677,12 @@ get_range(bitstr_t * bits, int low, int high, const char *names[],
 	if (state != R_FINISH || ch == EOF)
 		return (EOF);
 
+	/* Make sure the step size makes any sense */
+	if (step > 1 && step > (high_ - low_)) {
+		int max =  high_ - low_ > 0 ? high_ - low_ : 1;
+		fprintf(stderr, "Warning: Step size %i higher than possible maximum of %i\n", step, max);
+	}
+
 	for (i = low_; i <= high_; i += step)
 		if (EOF == set_element(bits, low, high, i)) {
 			unget_char(ch, file);


### PR DESCRIPTION
When using stepwise notation, there is no cron-error when a step-size is
picked which is bigger than the max. value of the field.
E.g. the following entry is valid:` */500 */400 */31 */12 */300 MyCommand`
And, as far as I can tell, will be interpreted as:  `* * * Jan *`

A step size, which is bigger than the specified range actually does not make much sense, and it would be nice to see a warning, when used. In this PR I did a fallback to the default stepsize in that case ... hope that would be fine ?

- First commit: renamed variables "num1, num2, num3" to "low_, high_, step" to improve
readability of the method
- Second commit: Print Message to stderr when an out of bound stepsize is specified Reset the stepsize to the default "1" if an out of bound stepsize is specified

Even though step-sizes bigger than (max-min)/2 do not make much sense,
it is possible to use them in some way (see [e.g. see here](https://en.wikipedia.org/wiki/Cron#Non-standard_characters) ). So I kept support for them, and used "max-min" to restrict step-size.

For testing, I used the attached cron files and did the following:

```
$ sudo ./src/crontab ../example-crontab-invalid
Step size of '500' will be ignored, since it exceeds the maximum possible step size of '59' for the specified entry'
Step size of '400' will be ignored, since it exceeds the maximum possible step size of '23' for the specified entry'
Step size of '31' will be ignored, since it exceeds the maximum possible step size of '30' for the specified entry'
Step size of '12' will be ignored, since it exceeds the maximum possible step size of '11' for the specified entry'
Step size of '300' will be ignored, since it exceeds the maximum possible step size of '7' for the specified entry'
$ sudo ./src/crontab ../example-crontab-invalid2
Step size of '11' will be ignored for this entry, since it exceeds the maximum possible step size of '10' for the specifed range of '10-20'
Step size of '20' will be ignored for this entry, since it exceeds the maximum possible step size of '10' for the specifed range of '10-20'
Step size of '2' will be ignored for this entry, since it exceeds the maximum possible step size of '1' for the specifed range of '4-4'
Step size of '3' will be ignored for this entry, since it exceeds the maximum possible step size of '1' for the specifed range of '1-2'
```
 
[testfiles.zip](https://github.com/cronie-crond/cronie/files/12841539/testfiles.zip)

