### PR TITLE
make the environment file optional

### DIFF
--- a/contrib/cronie.systemd
+++ b/contrib/cronie.systemd
@@ -3,7 +3,7 @@ Description=Command Scheduler
 After=auditd.service nss-user-lookup.target systemd-user-sessions.service time-sync.target ypbind.service autofs.service
 
 [Service]
-EnvironmentFile=/etc/sysconfig/crond
+EnvironmentFile=-/etc/sysconfig/crond
 ExecStart=/usr/sbin/crond -n $CRONDARGS
 ExecReload=/bin/kill -URG $MAINPID
 KillMode=process


### PR DESCRIPTION
Starting the daemon works without additional environment variables, so make the file optional.