### PR TITLE
re-introduce the test for existence of file

### DIFF
--- a/contrib/0anacron
+++ b/contrib/0anacron
@@ -8,7 +8,9 @@ if [ `date +%Y%m%d` = "$day" ]; then
 fi
 
 # Check whether run on battery should be allowed
-. /etc/default/anacron
+if test -r /etc/default/anacron; then
+    . /etc/default/anacron
+fi
 
 if [ "$ANACRON_RUN_ON_BATTERY_POWER" != "yes" ]; then
 


### PR DESCRIPTION
If the file does not exist it exits early with error... Let's source only if files acutually does exist. We still have a sane default.