### PR TITLE
-n option: wait on finnishing grandchild process

### DIFF
--- a/src/do_command.c
+++ b/src/do_command.c
@@ -577,7 +577,7 @@ static int child_process(entry * e, char **jobenv) {
 			if (mail && e->flags & MAIL_WHEN_ERR) {
 				int jobstatus = -1;
 				if (jobpid > 0) {
-					while (waitpid(jobpid, &jobstatus, WNOHANG) == -1) {
+					while (waitpid(jobpid, &jobstatus, 0) == -1) {
 						if (errno == EINTR) continue;
 						log_it("CRON", getpid(), "error", "invalid job pid", errno);
 						break;


### PR DESCRIPTION
With `WNOHANG` we skip sending the email when waitpid() returns 0, which happens if the process is still running. Instead, using `0` parameter will wait for the process to actually stop running.

This issue has been present, because of adapting [NetBSD cron](https://github.com/NetBSD/src/blob/fbbc9eb88e85e2bc40715e9140f0f03e010a4346/external/bsd/cron/dist/do_command.c#L257C5-L257C5), instead of [OpenBSD cron 
](https://github.com/openbsd/src/blob/43312083f29b74c8f9ee9db3ada0c3566deb439c/usr.sbin/cron/do_command.c#L434) 
After some discussion, I think it is better to wait for the grandchild process to end, instead of skipping sending an email, but I'm open to discussion on how to make this better.
