### PR TITLE
Make GitHub Actions ensure that cronie keeps compiling without errors on Linux (fixes #174)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under GPL v2 or later
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    commit-message:
+      include: "scope"
+      prefix: "Actions"
+    directory: "/"
+    labels:
+      - "enhancement"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,99 @@
+# Copyright (c) 2024 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under GPL v2 or later
+
+name: Build on Linux
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 3 * * 5'  # Every Friday at 3am
+  workflow_dispatch:
+
+# Minimum permissions for security
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    name: Build (${{ matrix.cc }})
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cc: gcc-13
+            cxx: g++-13
+            clang_major_version: null
+            clang_repo_suffix: null
+            runs-on: ubuntu-22.04
+          - cc: clang-17
+            cxx: clang++-17
+            clang_major_version: 17
+            clang_repo_suffix: -17
+            runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Git branch
+        uses: actions/checkout@v4
+
+      - name: Add Clang/LLVM repositories
+        if: "${{ contains(matrix.cc, 'clang') }}"
+        run: |-
+          set -x
+          source /etc/os-release
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}${{ matrix.clang_repo_suffix }} main"
+
+      - name: Install build dependencies
+        run: |-
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            libaudit-dev \
+            libpam0g-dev \
+            libselinux1-dev
+
+      - name: Install build dependency Clang ${{ matrix.clang_major_version }}
+        if: "${{ contains(matrix.cc, 'clang') }}"
+        run: |-
+          sudo apt-get install --yes --no-install-recommends -V \
+              clang-${{ matrix.clang_major_version }}
+
+      - name: 'Bootstrap'
+        run: |-
+          ./autogen.sh
+
+      - name: 'Configure'
+        env:
+          CFLAGS: '-std=gnu99 -Wall -Wextra -pedantic -O1 -pipe'
+          LDFLAGS: '-Wl,--as-needed'
+        run: |-
+          set -x
+          mkdir build
+          cd build
+          configure_args=(
+            # Make build logs better explain themselves
+            --disable-silent-rules
+
+            # Enable more optional features to increase coverage
+            --enable-syscrontab
+            --with-audit
+            --with-inotify
+            --with-pam
+            --with-selinux
+          )
+          ../configure "${configure_args[@]}"
+
+      - name: 'Make'
+        run: |-
+          make -C build -j$(nproc)
+
+      - name: 'Install'
+        run: |-
+          set -x -o pipefail
+          make -C build install DESTDIR="${PWD}"/ROOT/
+          find ROOT/ | sort | xargs ls -ld
+
+      - name: 'Distcheck'
+        run: |-
+          set -x
+          make -C build distcheck


### PR DESCRIPTION
Fixes #174

Four things seem worth mentioning at the moment:
- I found multiple licenses used in this repository so I was not sure which one to best apply to these new files. I'll be happy with anything approved by both FSF and OSI, just let me know your preference and I'll apply that. That todo is the key only reason the pull request is marked as a draft at the moment, so it does not get merged by accident.
- I would love to use `-std=c99` and `-Werror` but the code would need related fixes first, and I wanted to keep this pull request dedicated to one thing and small enough to be easy to review.
- The `@v4` in `actions/checkout@v4` is not pinning the GitHub Action to a SHA1 only because I seem to be rather alone with being okay with the amount of pull requests that the SHA1-plus-version-comment edition gets you. If it is considered acceptable here, I'm happy to add that pinning bit of extra security, similar to https://github.com/libexpat/libexpat/pull/709 . PS: Yes, Dependabot can still auto-bump dependencies pinned like that (which I find amazing).

I'm happy to answer questions about this pull request and/or discuss adjustment of details :beers: 

CC @t8m