### PR TITLE
crontab.5: Correctly describe mail from behavior

### DIFF
--- a/man/crontab.5
+++ b/man/crontab.5
@@ -98,8 +98,8 @@ This option is useful if you decide to use /bin/mail instead of
 aliasing and UUCP usually does not read its mail.  If
 .I MAILFROM
 is defined (and non-empty), it is used as the envelope sender address,
-otherwise, ``root'' is used. This variable is also inherited from the
-crond process environment.
+otherwise, the username of the executing user is used. This variable is
+also inherited from the crond process environment.
 .PP 
 (Note: Both 
 .I MAILFROM


### PR DESCRIPTION
The man page claimed that mails without a configured MAILFROM variable would be sent from the root mail address. However, the actual behavior is that mails are sent from the user's username, not necessarily root.