### PR TITLE
get_range() fix range parsing for Sunday as 0 or 7

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -642,6 +642,9 @@ get_range(bitstr_t * bits, int low, int high, const char *names[],
 					state = R_FINISH;
 					break;
 				}
+				if (low_ > high_ && high_ == 0) {
+					high_ = 7;
+				}
 				return (EOF);
 
 			case R_RANDOM:


### PR DESCRIPTION
In fc8b0e5, we changed how the ranges are parsed. This created a regression for parsing Sunday at the end of the range. This commit adds the logic to correctly handle Sunday as the end of the range.

Before the commit:
```
$ cat testcron
0 0 * * sat-sun /usr/bin/echo test

$ cronnext -c testcron 
spool: /var/spool/cron
crontabs:
  - user: "testcron"
    crontab: testcron
    system: 0
    entries:

```

After the commit:
```
$ cat testcron
0 0 * * sat-sun /usr/bin/echo test

$ cronnext -c testcron 
spool: /var/spool/cron
crontabs:
  - user: "testcron"
    crontab: testcron
    system: 0
    entries:
      - user: testcron
        cmd: "/usr/bin/echo test"
        flags: 0x04
        flagnames: DOM_STAR
        delay: 0
        next: 1741993200
        nextstring: Sat Mar 15 00:00:00 2025
next: 1741993200
```