### PR TITLE
get_range() move parsing code before separator check

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -638,12 +638,12 @@ get_range(bitstr_t * bits, int low, int high, const char *names[],
 					state = R_STEP;
 					break;
 				}
+				if (low_ > high_ && high_ == 0) {
+					high_ = 7;
+				}
 				if (is_separator(ch)) {
 					state = R_FINISH;
 					break;
-				}
-				if (low_ > high_ && high_ == 0) {
-					high_ = 7;
 				}
 				return (EOF);
 


### PR DESCRIPTION
In the previous commit the parsing fix was added after a separator check by accident, making it not execute properly. This commit moves it into the right place.

By a mistake, I've commited a different patch than I was using for testing. Sorry for the added noise in the commit log.