### PR TITLE
fix incorrect logging

### DIFF
--- a/src/cron.c
+++ b/src/cron.c
@@ -328,9 +328,9 @@ int main(int argc, char *argv[]) {
 	else {
 		reset_watches();
 		database.ifd = fd = inotify_init();
-		fcntl(fd, F_SETFD, FD_CLOEXEC);
 		if (fd < 0)
 			log_it("CRON", pid, "INFO", "Inotify init failed", errno);
+		fcntl(fd, F_SETFD, FD_CLOEXEC);
 		set_cron_watched(fd);
 	}
 #endif


### PR DESCRIPTION
`errno` in `log_it` call actually belonged to `fcntl` and always equaled `EBADF` ("bad file descriptor" since NULL was passed to `fcntl` as the 1st argument). The bug was introduced here: https://github.com/cronie-crond/cronie/commit/0c43f4b4b8e39f32e3c6eeaed944f5cd3ee0508f