### PR TITLE
doc: fix invalid step syntax example in crontab(5)

### DIFF
--- a/man/crontab.5
+++ b/man/crontab.5
@@ -293,7 +293,7 @@ MAILTO=root
 .fi
 .SH NOTES
 As noted above, skip values only operate within the time period they\'re
-attached to. For example, specifying "0/35" for the minute field of a
+attached to. For example, specifying "*/35" for the minute field of a
 crontab entry won\'t cause that entry to be executed every 35 minutes;
 instead, it will be executed twice every hour, at 0 and 35 minutes past.
 For more fine-grained control you can do something like this:


### PR DESCRIPTION
The crontab(5) man page contained an example using the syntax `0/35`, which seems to be invalid in cronie (A in `A/B` must be explicit like `0-59/35` or wildcard like `*/35`).

This change updates the example to use `*/35`.