### PR TITLE
Forward XDG_SESSION_CLASS to PAM for session classification

### DIFF
--- a/man/crontab.5
+++ b/man/crontab.5
@@ -157,6 +157,16 @@ upper limit specified by the variable. The random scaling factor is
 determined during the cron daemon startup so it remains constant for
 the whole run time of the daemon.
 .PP
+The
+.I XDG_SESSION_CLASS
+variable specifies the session class to be used when PAM creates a systemd
+session for the cron job.  If set (e.g., to "background-light"), this value
+is forwarded to the PAM environment so that
+.BR pam_systemd (8)
+can use it for session classification.  This allows cron jobs to run in
+lighter-weight sessions that consume fewer system resources.  This variable
+has no effect if crond was built without PAM support.
+.PP
 The format of a cron command is similar to the V7 standard, with a number
 of upward-compatible extensions.  Each line has five time-and-date fields
 followed by a


### PR DESCRIPTION
Allow users to set the XDG_SESSION_CLASS environment variable in their crontab to control the systemd session class for cron jobs. When set, this value is forwarded to the PAM environment so that pam_systemd can use it for session classification (e.g., "background-light").

This enables cron jobs to run in lighter-weight sessions that consume fewer system resources.